### PR TITLE
add: Authentication/Authorization

### DIFF
--- a/services/ai-copilot-service/main.py
+++ b/services/ai-copilot-service/main.py
@@ -1,8 +1,14 @@
 import os
 import logging
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from atlas_observability import (
     AtlasLoggingMiddleware, AtlasMetricsMiddleware, CorrelationIdMiddleware,
@@ -55,6 +61,47 @@ async def lifespan(app: FastAPI):
     logger.info("AI Copilot Service shutdown — cleaned %d expired sessions", expired)
 
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 app = FastAPI(
     title="Atlas AI Copilot Service",
     description="Workforce Intelligence — AI Copilot, Predictive Analytics, "
@@ -77,6 +124,26 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
+
 
 # ──────────────────────────────────────────────
 #  Health check

--- a/services/ai-service/main.py
+++ b/services/ai-service/main.py
@@ -1,6 +1,11 @@
 import logging
 import os
 import uuid
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Optional
@@ -66,6 +71,47 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 async def lifespan(app: FastAPI):
     yield
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 app = FastAPI(
     title="Atlas AI Service",
     description="Enterprise AI features: copilots, predictions, forecasting, automation, and autonomous intelligence",
@@ -87,6 +133,25 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
 
 
 MAX_REQUEST_SIZE = 1_000_000

--- a/services/analytics-python-service/main.py
+++ b/services/analytics-python-service/main.py
@@ -1,10 +1,14 @@
 import logging
-from fastapi import FastAPI, HTTPException, Header
+from fastapi import FastAPI, HTTPException, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
 import pandas as pd
 import os
 import uvicorn
+import base64
+import hashlib
+import hmac
 from sqlalchemy import create_engine, text
 from openai import OpenAI
 import json
@@ -17,6 +21,47 @@ from atlas_observability import (
     AtlasLoggingMiddleware, AtlasMetricsMiddleware, CorrelationIdMiddleware,
     configure_logging, get_logger
 )
+
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
 
 app = FastAPI(title="Analytics Service API", version="2.0.0")
 
@@ -81,6 +126,26 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
+
 
 POSTGRES_USER = os.environ.get("POSTGRES_USER", "atlas_user")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "atlas_password")

--- a/services/api-gateway-node/index.js
+++ b/services/api-gateway-node/index.js
@@ -85,16 +85,26 @@ const app = express();
 const PORT = process.env.PORT || 8080;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const JWT_SECRET = process.env.JWT_SECRET;
-const INTERNAL_JWT_SECRET = process.env.INTERNAL_JWT_SECRET || 'internal-dev-secret-change-in-prod';
-const AUDIT_INTERNAL_KEY = process.env.AUDIT_INTERNAL_KEY || 'atlas-internal-key-change-in-prod';
+const INTERNAL_JWT_SECRET = process.env.INTERNAL_JWT_SECRET;
+const AUDIT_INTERNAL_KEY = process.env.AUDIT_INTERNAL_KEY;
 const AUDIT_SERVICE_URL = process.env.AUDIT_COMPLIANCE_SERVICE_URL || 'http://audit-compliance-service:8011';
 
-if (!JWT_SECRET && NODE_ENV === 'production') {
-  console.error('FATAL: JWT_SECRET is required in production');
+if (!INTERNAL_JWT_SECRET) {
+  console.error('FATAL: INTERNAL_JWT_SECRET is required');
   process.exit(1);
 }
 
-const jwtSecret = JWT_SECRET || 'dev-only-secret-change-in-production';
+if (!AUDIT_INTERNAL_KEY) {
+  console.error('FATAL: AUDIT_INTERNAL_KEY is required');
+  process.exit(1);
+}
+
+if (!JWT_SECRET) {
+  console.error('FATAL: JWT_SECRET is required');
+  process.exit(1);
+}
+
+const jwtSecret = JWT_SECRET;
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
   .split(',')

--- a/services/ats-service/main.py
+++ b/services/ats-service/main.py
@@ -1,10 +1,16 @@
 import logging
 import os
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker, Session
 from atlas_observability import (
@@ -50,6 +56,47 @@ async def lifespan(app: FastAPI):
     engine.dispose()
 
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 app = FastAPI(title="ATS Service API", version="1.0.0", lifespan=lifespan)
 
 configure_logging("ats-service", level=logging.INFO)
@@ -70,6 +117,25 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/services/attendance-service/auth.go
+++ b/services/attendance-service/auth.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var internalJWTSecret []byte
+
+func initAuth() {
+	secret := os.Getenv("INTERNAL_JWT_SECRET")
+	if secret == "" {
+		panic("FATAL: INTERNAL_JWT_SECRET environment variable is required")
+	}
+	internalJWTSecret = []byte(secret)
+}
+
+func authMiddleware(c *fiber.Ctx) error {
+	path := c.Path()
+	if path == "/health" {
+		return c.Next()
+	}
+
+	internalToken := c.Get("x-internal-auth")
+	if internalToken == "" {
+		return c.Status(401).JSON(fiber.Map{"error": "Missing internal authentication"})
+	}
+
+	token, err := jwt.Parse(internalToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fiber.NewError(401, "Invalid signing method")
+		}
+		return internalJWTSecret, nil
+	})
+
+	if err != nil || !token.Valid {
+		return c.Status(401).JSON(fiber.Map{"error": "Invalid internal authentication"})
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return c.Status(401).JSON(fiber.Map{"error": "Invalid token claims"})
+	}
+
+	userID, _ := claims["user_id"].(string)
+	userRole, _ := claims["user_role"].(string)
+	tenantID, _ := claims["tenant_id"].(string)
+
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	if userRole == "" {
+		userRole = "employee"
+	}
+
+	c.Locals("user_id", userID)
+	c.Locals("user_role", userRole)
+	c.Locals("tenant_id", tenantID)
+
+	return c.Next()
+}
+
+func getTenant(c *fiber.Ctx) string {
+	if v, ok := c.Locals("tenant_id").(string); ok && v != "" {
+		return v
+	}
+	return "default"
+}
+
+func getUserRole(c *fiber.Ctx) string {
+	if v, ok := c.Locals("user_role").(string); ok {
+		return v
+	}
+	return "employee"
+}
+
+func getUserID(c *fiber.Ctx) string {
+	if v, ok := c.Locals("user_id").(string); ok {
+		return v
+	}
+	return ""
+}

--- a/services/attendance-service/go.mod
+++ b/services/attendance-service/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/gofiber/fiber/v2 v2.50.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/streadway/amqp v1.1.0
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/gorm v1.25.4

--- a/services/attendance-service/handlers.go
+++ b/services/attendance-service/handlers.go
@@ -15,14 +15,6 @@ import (
 // CORE ATTENDANCE HANDLERS
 // ============================================================
 
-func getTenant(c *fiber.Ctx) string {
-	tenant := c.Get("X-Tenant-Id")
-	if tenant == "" {
-		return "default"
-	}
-	return tenant
-}
-
 func getEmployeeID(c *fiber.Ctx) string {
 	return c.Get("X-Employee-Id")
 }

--- a/services/attendance-service/main.go
+++ b/services/attendance-service/main.go
@@ -250,6 +250,9 @@ func main() {
 		return c.JSON(fiber.Map{"status": "Attendance Service is running", "version": "2.0.0"})
 	})
 
+	initAuth()
+	app.Use(authMiddleware)
+
 	api := app.Group("/api/attendance")
 
 	// ============================================================

--- a/services/audit-compliance-service/main.py
+++ b/services/audit-compliance-service/main.py
@@ -5,10 +5,16 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
+import base64
+import hashlib
+import hmac
+import json
+import time
+
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import PlainTextResponse, Response
+from fastapi.responses import PlainTextResponse, Response, JSONResponse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from atlas_observability import (
@@ -148,6 +154,66 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
+
+
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
 
 async def verify_internal_key(x_internal_key: str = Header(...)):
     if x_internal_key != INTERNAL_API_KEY:

--- a/services/auth-service/index.js
+++ b/services/auth-service/index.js
@@ -39,34 +39,52 @@ app.use(
 const PORT = process.env.PORT || 8010;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const JWT_SECRET = process.env.JWT_SECRET;
-const ADMIN_DEFAULT_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD || 'ChangeMe123!';
+const ADMIN_DEFAULT_PASSWORD = process.env.ADMIN_DEFAULT_PASSWORD;
 const ACCESS_EXPIRY = '15m';
 const REFRESH_EXPIRY_DAYS = 7;
 const MAX_FAILED_ATTEMPTS = 5;
 const LOCKOUT_MINUTES = 15;
 const AUDIT_SERVICE_URL = process.env.AUDIT_SERVICE_URL || 'http://audit-compliance-service:8011';
-const AUDIT_INTERNAL_KEY = process.env.AUDIT_INTERNAL_KEY || 'atlas-internal-key-change-in-prod';
+const AUDIT_INTERNAL_KEY = process.env.AUDIT_INTERNAL_KEY;
 const SAML_IDP_SSO_URL = process.env.SAML_IDP_SSO_URL || 'https://idp.example.com/sso';
 const SAML_IDP_ENTITY_ID = process.env.SAML_IDP_ENTITY_ID || 'https://idp.example.com/metadata';
-const SCIM_API_KEY = process.env.SCIM_API_KEY || 'change-scim-api-key-in-production';
+const SCIM_API_KEY = process.env.SCIM_API_KEY;
 
-if (!JWT_SECRET && NODE_ENV === 'production') {
-  console.error('FATAL: JWT_SECRET is required in production');
+if (!JWT_SECRET) {
+  console.error('FATAL: JWT_SECRET environment variable is required');
   process.exit(1);
 }
 
-const jwtSecret = JWT_SECRET || 'dev-only-secret-change-in-production';
+if (!ADMIN_DEFAULT_PASSWORD) {
+  console.error('FATAL: ADMIN_DEFAULT_PASSWORD environment variable is required');
+  process.exit(1);
+}
+
+if (!AUDIT_INTERNAL_KEY) {
+  console.error('FATAL: AUDIT_INTERNAL_KEY environment variable is required');
+  process.exit(1);
+}
+
+if (!SCIM_API_KEY) {
+  console.error('FATAL: SCIM_API_KEY environment variable is required');
+  process.exit(1);
+}
+
+const jwtSecret = JWT_SECRET;
 
 const sslConfig = process.env.POSTGRES_SSL === 'true' || NODE_ENV === 'production'
-  ? { rejectUnauthorized: false }
+  ? { rejectUnauthorized: true }
   : false;
 
 const pool = new Pool({
-  connectionString:
-    process.env.POSTGRES_URL ||
-    `postgresql://${process.env.POSTGRES_USER || 'atlas_user'}:${process.env.POSTGRES_PASSWORD || 'atlas_password'}@${process.env.POSTGRES_HOST || 'postgres'}:5432/${process.env.POSTGRES_DB || 'atlas_db'}`,
+  connectionString: process.env.POSTGRES_URL,
   ssl: sslConfig,
 });
+
+if (!process.env.POSTGRES_URL) {
+  console.error('FATAL: POSTGRES_URL environment variable is required');
+  process.exit(1);
+}
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
 const redisClient = redis.createClient({ url: REDIS_URL });
@@ -567,7 +585,7 @@ initDB().catch((err) => {
 });
 
 app.post('/register', createUserRateLimiter('register', 10), async (req, res) => {
-  const { email, password, name, role, department, position, tenant_id } = req.body;
+  const { email, password, name, department, position, tenant_id } = req.body;
   if (!email || !password || !name) {
     return res.status(400).json({ message: 'Email, password, and name are required' });
   }
@@ -590,7 +608,7 @@ app.post('/register', createUserRateLimiter('register', 10), async (req, res) =>
         email,
         hashedPassword,
         name,
-        role || 'employee',
+        'employee',
         department || 'General',
         position || 'Staff',
         tenant_id || 'default'
@@ -598,7 +616,7 @@ app.post('/register', createUserRateLimiter('register', 10), async (req, res) =>
     );
 
     await sendAuditEvent('auth.register', result.rows[0].id, email, {
-      role: role || 'employee',
+      role: 'employee',
       tenant_id: tenant_id || 'default'
     });
 

--- a/services/employee-lifecycle-service/main.py
+++ b/services/employee-lifecycle-service/main.py
@@ -1,9 +1,15 @@
 import logging
 import os
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Depends, Header
+from fastapi import FastAPI, Depends, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from sqlalchemy import create_engine, text
@@ -42,6 +48,47 @@ async def lifespan(app: FastAPI):
     engine.dispose()
 
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 app = FastAPI(title="Employee Lifecycle Service API", version="1.0.0", lifespan=lifespan)
 
 configure_logging("employee-lifecycle-service", level=logging.INFO)
@@ -60,6 +107,25 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
 
 
 def custom_openapi():

--- a/services/employee-python-service/main.py
+++ b/services/employee-python-service/main.py
@@ -155,9 +155,9 @@ def validate_search_param(search: Optional[str]) -> Optional[str]:
 # ------------------------------------------------
 async def verify_internal_key(request: Request):
     x_internal_key = request.headers.get("X-Internal-Key")
-    if x_internal_key is not None and x_internal_key != INTERNAL_KEY:
+    if not x_internal_key or x_internal_key != INTERNAL_KEY:
         log_event("warning", "auth.invalid_internal_key")
-        raise HTTPException(status_code=403, detail="Invalid internal key")
+        raise HTTPException(status_code=403, detail="Invalid or missing internal key")
     return x_internal_key
 
 

--- a/services/integration-service/main.py
+++ b/services/integration-service/main.py
@@ -2,11 +2,16 @@ import logging
 import os
 import threading
 import time
+import base64
+import hashlib
+import hmac
+import json
 from contextlib import asynccontextmanager
 from uuid import UUID
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, Header, HTTPException, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -81,6 +86,47 @@ def get_db() -> Session:
         db.close()
 
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 async def verify_internal_key(x_internal_key: str = Header(...)):
     if x_internal_key != INTERNAL_API_KEY:
         raise HTTPException(status_code=403, detail="Invalid internal API key")
@@ -139,6 +185,25 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
 
 
 # ── Health ──────────────────────────────────────────────────────

--- a/services/leave-service/src/main/java/com/atlas/leave/InternalAuthFilter.java
+++ b/services/leave-service/src/main/java/com/atlas/leave/InternalAuthFilter.java
@@ -1,0 +1,103 @@
+package com.atlas.leave;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@Order(1)
+public class InternalAuthFilter implements Filter {
+
+    private final String internalJwtSecret;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public InternalAuthFilter(@Value("${INTERNAL_JWT_SECRET:}") String internalJwtSecret) {
+        this.internalJwtSecret = internalJwtSecret;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String path = request.getRequestURI();
+        if ("/health".equals(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (internalJwtSecret == null || internalJwtSecret.isEmpty()) {
+            sendError(response, 500, "Service not configured: INTERNAL_JWT_SECRET missing");
+            return;
+        }
+
+        String authHeader = request.getHeader("x-internal-auth");
+        if (authHeader == null || authHeader.isEmpty()) {
+            sendError(response, 401, "Missing internal authentication");
+            return;
+        }
+
+        try {
+            String[] parts = authHeader.split("\\.");
+            if (parts.length != 3) {
+                sendError(response, 401, "Invalid token format");
+                return;
+            }
+
+            String header = parts[0];
+            String payload = parts[1];
+            String signature = parts[2];
+
+            String expectedSignature = computeHmac(header + "." + payload, internalJwtSecret);
+            if (!expectedSignature.equals(signature)) {
+                sendError(response, 401, "Invalid token signature");
+                return;
+            }
+
+            String decodedPayload = new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(decodedPayload, Map.class);
+
+            long exp = claims.containsKey("exp") ? ((Number) claims.get("exp")).longValue() : 0;
+            if (System.currentTimeMillis() / 1000 > exp) {
+                sendError(response, 401, "Token expired");
+                return;
+            }
+
+            request.setAttribute("x-tenant-id", claims.getOrDefault("tenant_id", "default"));
+            request.setAttribute("x-user-role", claims.getOrDefault("user_role", "employee"));
+            request.setAttribute("x-user-id", claims.getOrDefault("user_id", ""));
+
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            sendError(response, 401, "Invalid internal authentication");
+        }
+    }
+
+    private String computeHmac(String data, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(keySpec);
+        byte[] hash = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+
+    private void sendError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(Map.of("error", message)));
+    }
+}

--- a/services/live-service/main.py
+++ b/services/live-service/main.py
@@ -7,6 +7,11 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Optional
+import base64
+import hashlib
+import hmac
+import time
+
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,6 +27,7 @@ load_dotenv()
 
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
 RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672/")
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET")
 
 # ── In-Memory Channel State ─────────────────────────────────────────────────
 
@@ -228,6 +234,66 @@ class ExecutiveUpdate(BaseModel):
     change: float
     trend: str
     category: str
+
+# ── Internal Auth ────────────────────────────────────────────────────────────
+
+def validate_internal_jwt(auth_header: str) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = validate_internal_jwt(auth_header)
+        request.state.user_id = claims.get("user_id", "")
+        request.state.user_role = claims.get("user_role", "employee")
+        request.state.tenant_id = claims.get("tenant_id", "default")
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
+
 
 # ── FastAPI App ─────────────────────────────────────────────────────────────
 

--- a/services/lms-service/go.mod
+++ b/services/lms-service/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	gorm.io/datatypes v1.2.0

--- a/services/lms-service/main.go
+++ b/services/lms-service/main.go
@@ -76,6 +76,8 @@ func main() {
 	app.Use(recover.New())
 	app.Use(logger.New())
 	app.Use(cors.New())
+	middleware.InitAuth()
+	app.Use(middleware.AuthMiddleware())
 	app.Use(middleware.TenantMiddleware())
 
 	go startCertExpiryChecker()

--- a/services/lms-service/middleware/auth.go
+++ b/services/lms-service/middleware/auth.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"os"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var internalJWTSecret []byte
+
+func InitAuth() {
+	secret := os.Getenv("INTERNAL_JWT_SECRET")
+	if secret == "" {
+		panic("FATAL: INTERNAL_JWT_SECRET environment variable is required")
+	}
+	internalJWTSecret = []byte(secret)
+}
+
+func AuthMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		path := c.Path()
+		if path == "/health" {
+			return c.Next()
+		}
+
+		internalToken := c.Get("x-internal-auth")
+		if internalToken == "" {
+			return c.Status(401).JSON(fiber.Map{"error": "Missing internal authentication"})
+		}
+
+		token, err := jwt.Parse(internalToken, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fiber.NewError(401, "Invalid signing method")
+			}
+			return internalJWTSecret, nil
+		})
+
+		if err != nil || !token.Valid {
+			return c.Status(401).JSON(fiber.Map{"error": "Invalid internal authentication"})
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			return c.Status(401).JSON(fiber.Map{"error": "Invalid token claims"})
+		}
+
+		userID, _ := claims["user_id"].(string)
+		userRole, _ := claims["user_role"].(string)
+		tenantID, _ := claims["tenant_id"].(string)
+
+		if tenantID == "" {
+			tenantID = "default"
+		}
+		if userRole == "" {
+			userRole = "employee"
+		}
+
+		c.Locals("user_id", userID)
+		c.Locals("user_role", userRole)
+		c.Locals("tenant_id", tenantID)
+
+		return c.Next()
+	}
+}

--- a/services/lms-service/middleware/tenant.go
+++ b/services/lms-service/middleware/tenant.go
@@ -6,10 +6,10 @@ import (
 
 func TenantMiddleware() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		tenantID := c.Get("X-Tenant-ID")
-		if tenantID == "" {
-			tenantID = c.Query("tenant_id")
+		if v, ok := c.Locals("tenant_id").(string); ok && v != "" {
+			return c.Next()
 		}
+		tenantID := c.Get("X-Tenant-ID")
 		if tenantID == "" {
 			tenantID = "default"
 		}
@@ -23,4 +23,18 @@ func GetTenant(c *fiber.Ctx) string {
 		return v
 	}
 	return "default"
+}
+
+func GetUserRole(c *fiber.Ctx) string {
+	if v, ok := c.Locals("user_role").(string); ok {
+		return v
+	}
+	return "employee"
+}
+
+func GetUserID(c *fiber.Ctx) string {
+	if v, ok := c.Locals("user_id").(string); ok {
+		return v
+	}
+	return ""
 }

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -113,7 +113,7 @@ var (
 func validateJWT(tokenString string) (jwt.MapClaims, error) {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		secret = "dev-only-secret-change-in-production"
+		return nil, fmt.Errorf("JWT_SECRET not configured")
 	}
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -128,6 +128,47 @@ func validateJWT(tokenString string) (jwt.MapClaims, error) {
 		return claims, nil
 	}
 	return nil, fmt.Errorf("invalid token")
+}
+
+func internalAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		internalKey := os.Getenv("INTERNAL_JWT_SECRET")
+		if internalKey == "" {
+			http.Error(w, `{"error":"Service not configured"}`, http.StatusInternalServerError)
+			return
+		}
+
+		internalToken := r.Header.Get("x-internal-auth")
+		if internalToken == "" {
+			http.Error(w, `{"error":"Missing internal authentication"}`, http.StatusUnauthorized)
+			return
+		}
+
+		token, err := jwt.Parse(internalToken, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return []byte(internalKey), nil
+		})
+
+		if err != nil || !token.Valid {
+			http.Error(w, `{"error":"Invalid internal authentication"}`, http.StatusUnauthorized)
+			return
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			http.Error(w, `{"error":"Invalid token claims"}`, http.StatusUnauthorized)
+			return
+		}
+
+		tenantID, _ := claims["tenant_id"].(string)
+		if tenantID != "" {
+			r.Header.Set("X-Tenant-Id", tenantID)
+		}
+
+		next(w, r)
+	}
 }
 
 func (c *Client) writePump() {
@@ -416,8 +457,8 @@ func main() {
 	// WebSocket
 	mux.HandleFunc("/ws", handleConnections)
 
-	// REST API for notifications
-	mux.HandleFunc("/api/notifications", func(w http.ResponseWriter, r *http.Request) {
+	// REST API for notifications (requires internal auth)
+	mux.HandleFunc("/api/notifications", internalAuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Tenant-Id")
@@ -435,7 +476,7 @@ func main() {
 		default:
 			http.Error(w, `{"error":"Method not allowed"}`, http.StatusMethodNotAllowed)
 		}
-	})
+	}))
 
 	log.Printf("Notification Service listening on port %s", port)
 	if err := http.ListenAndServe(":"+port, mux); err != nil {

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/InternalAuthFilter.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/InternalAuthFilter.java
@@ -1,0 +1,103 @@
+package com.ems.payroll;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@Order(1)
+public class InternalAuthFilter implements Filter {
+
+    private final String internalJwtSecret;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public InternalAuthFilter(@Value("${INTERNAL_JWT_SECRET:}") String internalJwtSecret) {
+        this.internalJwtSecret = internalJwtSecret;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String path = request.getRequestURI();
+        if ("/health".equals(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (internalJwtSecret == null || internalJwtSecret.isEmpty()) {
+            sendError(response, 500, "Service not configured: INTERNAL_JWT_SECRET missing");
+            return;
+        }
+
+        String authHeader = request.getHeader("x-internal-auth");
+        if (authHeader == null || authHeader.isEmpty()) {
+            sendError(response, 401, "Missing internal authentication");
+            return;
+        }
+
+        try {
+            String[] parts = authHeader.split("\\.");
+            if (parts.length != 3) {
+                sendError(response, 401, "Invalid token format");
+                return;
+            }
+
+            String header = parts[0];
+            String payload = parts[1];
+            String signature = parts[2];
+
+            String expectedSignature = computeHmac(header + "." + payload, internalJwtSecret);
+            if (!expectedSignature.equals(signature)) {
+                sendError(response, 401, "Invalid token signature");
+                return;
+            }
+
+            String decodedPayload = new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(decodedPayload, Map.class);
+
+            long exp = claims.containsKey("exp") ? ((Number) claims.get("exp")).longValue() : 0;
+            if (System.currentTimeMillis() / 1000 > exp) {
+                sendError(response, 401, "Token expired");
+                return;
+            }
+
+            request.setAttribute("x-tenant-id", claims.getOrDefault("tenant_id", "default"));
+            request.setAttribute("x-user-role", claims.getOrDefault("user_role", "employee"));
+            request.setAttribute("x-user-id", claims.getOrDefault("user_id", ""));
+
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            sendError(response, 401, "Invalid internal authentication: " + e.getMessage());
+        }
+    }
+
+    private String computeHmac(String data, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(keySpec);
+        byte[] hash = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+
+    private void sendError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(Map.of("error", message)));
+    }
+}

--- a/services/performance-service/src/main/java/com/atlas/performance/InternalAuthFilter.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/InternalAuthFilter.java
@@ -1,0 +1,103 @@
+package com.atlas.performance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@Order(1)
+public class InternalAuthFilter implements Filter {
+
+    private final String internalJwtSecret;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public InternalAuthFilter(@Value("${INTERNAL_JWT_SECRET:}") String internalJwtSecret) {
+        this.internalJwtSecret = internalJwtSecret;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String path = request.getRequestURI();
+        if ("/health".equals(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (internalJwtSecret == null || internalJwtSecret.isEmpty()) {
+            sendError(response, 500, "Service not configured: INTERNAL_JWT_SECRET missing");
+            return;
+        }
+
+        String authHeader = request.getHeader("x-internal-auth");
+        if (authHeader == null || authHeader.isEmpty()) {
+            sendError(response, 401, "Missing internal authentication");
+            return;
+        }
+
+        try {
+            String[] parts = authHeader.split("\\.");
+            if (parts.length != 3) {
+                sendError(response, 401, "Invalid token format");
+                return;
+            }
+
+            String header = parts[0];
+            String payload = parts[1];
+            String signature = parts[2];
+
+            String expectedSignature = computeHmac(header + "." + payload, internalJwtSecret);
+            if (!expectedSignature.equals(signature)) {
+                sendError(response, 401, "Invalid token signature");
+                return;
+            }
+
+            String decodedPayload = new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(decodedPayload, Map.class);
+
+            long exp = claims.containsKey("exp") ? ((Number) claims.get("exp")).longValue() : 0;
+            if (System.currentTimeMillis() / 1000 > exp) {
+                sendError(response, 401, "Token expired");
+                return;
+            }
+
+            request.setAttribute("x-tenant-id", claims.getOrDefault("tenant_id", "default"));
+            request.setAttribute("x-user-role", claims.getOrDefault("user_role", "employee"));
+            request.setAttribute("x-user-id", claims.getOrDefault("user_id", ""));
+
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            sendError(response, 401, "Invalid internal authentication");
+        }
+    }
+
+    private String computeHmac(String data, String secret) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(keySpec);
+        byte[] hash = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+    }
+
+    private void sendError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(Map.of("error", message)));
+    }
+}

--- a/services/security-service/main.py
+++ b/services/security-service/main.py
@@ -1,12 +1,18 @@
 import logging
 import os
 import uuid
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Optional
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from atlas_observability import (
@@ -60,6 +66,47 @@ def get_db() -> Session:
     finally:
         db.close()
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 async def verify_internal_key(x_internal_key: str = Header(...)):
     if x_internal_key != INTERNAL_API_KEY:
         raise HTTPException(status_code=403, detail="Invalid internal API key")
@@ -101,6 +148,26 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
+
 
 # ── Health ──────────────────────────────────────────────────────────────────
 

--- a/services/workforce-planning-service/main.py
+++ b/services/workforce-planning-service/main.py
@@ -1,9 +1,15 @@
 import logging
 import os
+import base64
+import hashlib
+import hmac
+import json
+import time
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Depends, Header
+from fastapi import FastAPI, Depends, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from sqlalchemy import create_engine, text
@@ -42,6 +48,47 @@ async def lifespan(app: FastAPI):
     engine.dispose()
 
 
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
+
+def verify_internal_auth(request: Request) -> dict:
+    if not INTERNAL_JWT_SECRET:
+        raise HTTPException(status_code=500, detail="Service not configured")
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        raise HTTPException(status_code=401, detail="Missing internal authentication")
+
+    try:
+        parts = auth_header.split(".")
+        if len(parts) != 3:
+            raise HTTPException(status_code=401, detail="Invalid token format")
+
+        _header_b64, payload_b64, signature = parts
+
+        expected = hmac.new(
+            INTERNAL_JWT_SECRET.encode(),
+            f"{_header_b64}.{payload_b64}".encode(),
+            hashlib.sha256,
+        )
+        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
+
+        if not hmac.compare_digest(expected_sig, signature):
+            raise HTTPException(status_code=401, detail="Invalid token signature")
+
+        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+
+        exp = claims.get("exp", 0)
+        if exp and time.time() > exp:
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return claims
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid internal authentication")
+
 app = FastAPI(title="Workforce Planning Service API", version="1.0.0", lifespan=lifespan)
 
 configure_logging("workforce-planning-service", level=logging.INFO)
@@ -60,6 +107,25 @@ app.add_middleware(
 app.add_middleware(CorrelationIdMiddleware)
 app.add_middleware(AtlasLoggingMiddleware)
 app.add_middleware(AtlasMetricsMiddleware)
+
+
+@app.middleware("http")
+async def internal_auth_middleware(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    auth_header = request.headers.get("x-internal-auth")
+    if not auth_header:
+        return JSONResponse(status_code=401, content={"error": "Missing internal authentication"})
+
+    try:
+        claims = verify_internal_auth(request)
+    except HTTPException as e:
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail})
+    except Exception:
+        return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
+
+    return await call_next(request)
 
 
 def custom_openapi():


### PR DESCRIPTION
Most services rely solely on X-Tenant-Id and X-User-Role HTTP headers from the client with zero verification. Any client can impersonate any tenant or role. The attendance service (Go/Fiber) has no middleware at all — all endpoints are fully public.

Files:

services/attendance-service/main.go:249 — No auth middleware services/payroll-java-service/.../PayrollController.java:40-41 — Client controls X-User-Role: admin services/live-service/main.py — All endpoints public services/lms-service/handlers/*.go — No auth checks