### PR TITLE
fix: store JWT in httpOnly cookie instead of localStorage

### DIFF
--- a/frontend/src/app/api/auth/token/route.ts
+++ b/frontend/src/app/api/auth/token/route.ts
@@ -1,0 +1,8 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("access_token")?.value;
+  return NextResponse.json({ token: token ?? null });
+}

--- a/frontend/src/components/auth/auth-guard.tsx
+++ b/frontend/src/components/auth/auth-guard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { isAuthenticated } from "@/lib/auth";
+import { isAuthenticated, isInitialized, initializeAuth } from "@/lib/auth";
 import { useAuthStore } from "@/stores/auth-store";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -10,10 +10,20 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const user = useAuthStore((s) => s.user);
-  const authenticated = isAuthenticated() || !!user;
+  const [ready, setReady] = useState(isInitialized());
 
   useEffect(() => {
-    if (!authenticated) {
+    if (!isInitialized()) {
+      initializeAuth().then(() => setReady(true));
+    } else {
+      setReady(true);
+    }
+  }, []);
+
+  const authenticated = ready && (isAuthenticated() || !!user);
+
+  useEffect(() => {
+    if (ready && !authenticated) {
       const redirect = searchParams?.get("redirect");
       if (redirect) {
         router.replace("/login?redirect=" + encodeURIComponent(redirect));
@@ -26,9 +36,9 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
         }
       }
     }
-  }, [authenticated, router, searchParams]);
+  }, [authenticated, ready, router, searchParams]);
 
-  if (!authenticated) {
+  if (!ready || !authenticated) {
     return (
       <div className="flex h-screen items-center justify-center gap-4 p-8">
         <Skeleton className="h-12 w-12 rounded-full" />

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,18 +1,42 @@
-const TOKEN_KEY = "atlas_access_token";
 const USER_KEY = "atlas_user";
 
+let inMemoryToken: string | null = null;
+let _initialized = false;
+
 export function getAccessToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem(TOKEN_KEY);
+  return inMemoryToken;
 }
 
 export function setTokens(access: string): void {
-  localStorage.setItem(TOKEN_KEY, access);
+  inMemoryToken = access;
 }
 
 export function clearAuth(): void {
-  localStorage.removeItem(TOKEN_KEY);
+  inMemoryToken = null;
+  _initialized = false;
   localStorage.removeItem(USER_KEY);
+}
+
+export async function initializeAuth(): Promise<boolean> {
+  if (typeof window === "undefined") return false;
+  if (_initialized) return true;
+  try {
+    const res = await fetch("/api/auth/token");
+    const data = await res.json();
+    if (data.token) {
+      inMemoryToken = data.token;
+      _initialized = true;
+      return true;
+    }
+  } catch {
+    // network error — proceed as unauthenticated
+  }
+  _initialized = true;
+  return false;
+}
+
+export function isInitialized(): boolean {
+  return _initialized;
 }
 
 export function setStoredUser(user: object): void {

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import type { User } from "@/types";
 import {
   clearAuth,
+  initializeAuth,
   setStoredUser,
   setTokens,
 } from "@/lib/auth";
@@ -21,6 +22,7 @@ interface AuthState {
   }) => Promise<void>;
   logout: () => void;
   setUser: (user: User | null) => void;
+  initialize: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -29,6 +31,9 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       isLoading: false,
       setUser: (user) => set({ user }),
+      initialize: async () => {
+        await initializeAuth();
+      },
       login: async (email, password) => {
         set({ isLoading: true });
         try {
@@ -76,6 +81,9 @@ export const useAuthStore = create<AuthState>()(
         if (typeof window !== "undefined") window.location.href = "/login";
       },
     }),
-    { name: "atlas-auth", partialize: (s) => ({ user: s.user }) }
+    {
+      name: "atlas-auth",
+      partialize: (s) => ({ user: s.user }),
+    }
   )
 );


### PR DESCRIPTION
- Remove token from localStorage (XSS-vulnerable)
- Store token in-memory only, set httpOnly cookie for middleware
- Add /api/auth/token endpoint to restore token from cookie on refresh
- Update AuthGuard to initialize auth from cookie on mount