### PR TITLE
fix: token refresh broken — user logged out after first token expiry

### DIFF
--- a/frontend/src/components/auth/auth-guard.tsx
+++ b/frontend/src/components/auth/auth-guard.tsx
@@ -10,7 +10,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const user = useAuthStore((s) => s.user);
-  const authenticated = isAuthenticated() || !!user;
+  const authenticated = isAuthenticated();
 
   useEffect(() => {
     if (!authenticated) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -36,6 +36,7 @@ const API_BASE =
 export const api = axios.create({
   baseURL: API_BASE,
   headers: { "Content-Type": "application/json" },
+  withCredentials: true,
 });
 
 api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
@@ -80,7 +81,7 @@ api.interceptors.response.use(
     refreshing = true;
 
     try {
-      const { data } = await axios.post(`${API_BASE}/auth/refresh`);
+      const { data } = await api.post("/auth/refresh");
       setTokens(data.token);
       processQueue(data.token);
       original.headers.Authorization = `Bearer ${data.token}`;
@@ -110,6 +111,7 @@ function validateResponse<T>(schema: z.ZodType<T>, data: unknown): T {
 
 const loginResponseSchema = z.object({
   token: z.string().min(1),
+  refreshToken: z.string().optional(),
   user: z.object({
     id: z.number(),
     email: z.string().email(),


### PR DESCRIPTION
## Issue 1: Token Refresh Fundamentally Broken\n\n### Root Causes & Fixes\n\n**1. Missing \withCredentials: true\**\n- The Axios instance never had \withCredentials\, so httpOnly cookies (containing the refresh token) were never sent\n- The bare \xios.post()\ in the refresh interceptor also lacked it\n- **Fix:** Added \withCredentials: true\ to the Axios instance and changed the interceptor to use \pi.post()\ (inherits the config)\n\n**2. refreshToken stripped by Zod validation**\n- \loginResponseSchema\ omitted \efreshToken\, so even when the API returns it, Zod strips it\n- \AuthResponse\ type already declares it as optional — the schema just wasn't matching\n- **Fix:** Added \efreshToken: z.string().optional()\ to the schema\n\n**3. Stale persisted user bypasses auth guard**\n- \AuthGuard\ used \isAuthenticated() || !!user\ — the \!!user\ falls back to the persisted Zustand user, which survives page reload even when the token is expired/invalid\n- **Fix:** Removed \!!user\; guard now only trusts \isAuthenticated()\ (checks actual access token)\n\n### Files changed\n- \rontend/src/lib/api.ts\ — \withCredentials\, interceptor refresh call, Zod schema\n- \rontend/src/components/auth/auth-guard.tsx\ — removed stale user fallback