### PR TITLE
fix: remove orphaned JWT verification block causing IndentationError in integration-service

### DIFF
--- a/services/integration-service/main.py
+++ b/services/integration-service/main.py
@@ -83,44 +83,6 @@ def get_db() -> Session:
         db.close()
 
 
-INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
-
-
-
-    auth_header = request.headers.get("x-internal-auth")
-    if not auth_header:
-        raise HTTPException(status_code=401, detail="Missing internal authentication")
-
-    try:
-        parts = auth_header.split(".")
-        if len(parts) != 3:
-            raise HTTPException(status_code=401, detail="Invalid token format")
-
-        _header_b64, payload_b64, signature = parts
-
-        expected = hmac.new(
-            INTERNAL_JWT_SECRET.encode(),
-            f"{_header_b64}.{payload_b64}".encode(),
-            hashlib.sha256,
-        )
-        expected_sig = base64.urlsafe_b64encode(expected.digest()).rstrip(b"=").decode()
-
-        if not hmac.compare_digest(expected_sig, signature):
-            raise HTTPException(status_code=401, detail="Invalid token signature")
-
-        padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
-        decoded = base64.urlsafe_b64decode(padded)
-        claims = json.loads(decoded)
-
-        exp = claims.get("exp", 0)
-        if exp and time.time() > exp:
-            raise HTTPException(status_code=401, detail="Token expired")
-
-        return claims
-    except HTTPException:
-        raise
-    except Exception:
-        raise HTTPException(status_code=401, detail="Invalid internal authentication")
 
 async def verify_internal_key(x_internal_key: str = Header(...)):
     if x_internal_key != INTERNAL_API_KEY:


### PR DESCRIPTION
## Problem

Lines 90-123 of \services/integration-service/main.py\ contained an indented JWT verification block with no enclosing function definition. This caused an \IndentationError\ on module load, preventing the service from starting.

## Solution

Removed the orphaned block entirely. Authentication is already handled by the existing \internal_auth_middleware\ (line 187) which calls \erify_internal_auth\ from \tlas_observability\.