### PR TITLE
fix: k8s ingress rewrites all paths, add TLS, securityContext, resource limits, probes

### DIFF
--- a/k8s/deployments.yaml
+++ b/k8s/deployments.yaml
@@ -14,11 +14,38 @@ spec:
       labels:
         app: api-gateway
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: api-gateway
         image: atlas/api-gateway:latest
         ports:
         - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -39,11 +66,38 @@ spec:
       labels:
         app: frontend
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: frontend
         image: atlas/frontend:latest
         ports:
         - containerPort: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,86 +115,38 @@ spec:
       labels:
         app: auth-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: auth-service
         image: atlas/auth-service:latest
         ports:
         - containerPort: 8010
-        envFrom:
-        - secretRef:
-            name: atlas-secrets
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: payroll-service
-  labels:
-    app: payroll-service
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: payroll-service
-  template:
-    metadata:
-      labels:
-        app: payroll-service
-    spec:
-      containers:
-      - name: payroll-service
-        image: atlas/payroll-service:latest
-        ports:
-        - containerPort: 8002
-        envFrom:
-        - secretRef:
-            name: atlas-secrets
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: analytics-service
-  labels:
-    app: analytics-service
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: analytics-service
-  template:
-    metadata:
-      labels:
-        app: analytics-service
-    spec:
-      containers:
-      - name: analytics-service
-        image: atlas/analytics-service:latest
-        ports:
-        - containerPort: 8003
-        envFrom:
-        - secretRef:
-            name: atlas-secrets
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: notification-service
-  labels:
-    app: notification-service
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: notification-service
-  template:
-    metadata:
-      labels:
-        app: notification-service
-    spec:
-      containers:
-      - name: notification-service
-        image: atlas/notification-service:latest
-        ports:
-        - containerPort: 8004
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8010
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8010
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -161,11 +167,194 @@ spec:
       labels:
         app: employee-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: employee-service
         image: atlas/employee-service:latest
         ports:
         - containerPort: 8001
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        envFrom:
+        - secretRef:
+            name: atlas-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payroll-service
+  labels:
+    app: payroll-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payroll-service
+  template:
+    metadata:
+      labels:
+        app: payroll-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+      - name: payroll-service
+        image: atlas/payroll-service:latest
+        ports:
+        - containerPort: 8002
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8002
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8002
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        envFrom:
+        - secretRef:
+            name: atlas-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analytics-service
+  labels:
+    app: analytics-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: analytics-service
+  template:
+    metadata:
+      labels:
+        app: analytics-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+      - name: analytics-service
+        image: atlas/analytics-service:latest
+        ports:
+        - containerPort: 8003
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8003
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        envFrom:
+        - secretRef:
+            name: atlas-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+  labels:
+    app: notification-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+      - name: notification-service
+        image: atlas/notification-service:latest
+        ports:
+        - containerPort: 8004
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8004
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8004
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -186,11 +375,38 @@ spec:
       labels:
         app: attendance-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: attendance-service
         image: atlas/attendance-service:latest
         ports:
         - containerPort: 8005
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8005
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8005
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -211,11 +427,38 @@ spec:
       labels:
         app: leave-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: leave-service
         image: atlas/leave-service:latest
         ports:
         - containerPort: 8006
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8006
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8006
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -236,11 +479,38 @@ spec:
       labels:
         app: audit-compliance-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: audit-compliance-service
         image: atlas/audit-compliance-service:latest
         ports:
         - containerPort: 8011
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8011
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8011
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -261,11 +531,38 @@ spec:
       labels:
         app: ats-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: ats-service
         image: atlas/ats-service:latest
         ports:
         - containerPort: 8012
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8012
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8012
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -286,11 +583,38 @@ spec:
       labels:
         app: lms-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: lms-service
         image: atlas/lms-service:latest
         ports:
         - containerPort: 8013
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8013
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8013
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -311,11 +635,38 @@ spec:
       labels:
         app: performance-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: performance-service
         image: atlas/performance-service:latest
         ports:
         - containerPort: 8014
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8014
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8014
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
@@ -336,12 +687,38 @@ spec:
       labels:
         app: ai-copilot-service
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
       - name: ai-copilot-service
         image: atlas/ai-copilot-service:latest
         ports:
         - containerPort: 8015
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8015
+          initialDelaySeconds: 10
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8015
+          initialDelaySeconds: 5
+          periodSeconds: 10
         envFrom:
         - secretRef:
             name: atlas-secrets
-

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -3,14 +3,21 @@ kind: Ingress
 metadata:
   name: atlas-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - atlas.local
+    secretName: atlas-tls
   rules:
   - host: atlas.local
     http:
       paths:
-      - path: /api
-        pathType: Prefix
+      - path: /api(/|$)(.*)
+        pathType: ImplementationSpecific
         backend:
           service:
             name: api-gateway


### PR DESCRIPTION
## Kubernetes Ingress & Deployment Security Fix

### Issues fixed

**1. Ingress rewrite-target: / breaks all routes**
- \
ginx.ingress.kubernetes.io/rewrite-target: /\ stripped every path to just \/\
- \/api/auth/login\ became \/\ when forwarded to the backend
- **Fix:** Changed to \/\ with regex path \/api(/|$)(.*)\ — preserves the subpath

**2. No TLS configured**
- Added \	ls\ section with \tlas-tls\ secret, \ssl-redirect: true\, and explicit \ingressClassName: nginx\

**3. No securityContext on any deployment**
- Added pod-level: \unAsNonRoot: true\, \unAsUser: 1001\, \sGroup: 1001\
- Added container-level: \llowPrivilegeEscalation: false\, \capabilities.drop: [ALL]\

**4. No resource limits**
- Added \equests\ (100m cpu / 128Mi memory) and \limits\ (500m cpu / 256Mi memory) on all 14 containers

**5. No liveness/readiness probes**
- Added \livenessProbe\ and \eadinessProbe\ (httpGet /health) with appropriate delays on all containers

### Files changed
- \k8s/ingress.yaml\ — fixed rewrite-target, added TLS, regex path capture
- \k8s/deployments.yaml\ — added securityContext, resource limits, probes to all deployments