### PR TITLE
fix: replace Axios responseType stream with native fetch for browser compatibility

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -701,8 +701,16 @@ export const copilotApi = {
   chat: {
     send: (message: string, sessionId?: string) =>
       api.post("/copilot/chat", { message, sessionId }),
-    stream: (message: string, sessionId?: string) =>
-      api.post("/copilot/chat/stream", { message, sessionId }, { responseType: "stream" }),
+    stream: (message: string, sessionId?: string): Promise<Response> => {
+      const token = getAccessToken();
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+      return fetch(`${API_BASE}/copilot/chat/stream`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ message, sessionId }),
+      });
+    },
   },
   sessions: {
     list: () => api.get("/copilot/sessions"),


### PR DESCRIPTION
## Problem

copilotApi.chat.stream() used api.post(..., { responseType: "stream" }) which is an Axios feature only available in Node.js. In browser environments, Axios does not support responseType: "stream" — the call would silently fail or throw.

## Solution

Replaced the Axios call with native fetch() that returns a Promise<Response>. The response body provides a ReadableStream via response.body.getReader() which is the standard browser API for consuming streaming responses.

The Authorization header is set from the in-memory token (via getAccessToken()), consistent with the rest of the API layer.