### PR TITLE
fix: chaos tests always exit 0 regardless of pass/fail (#68)

### DIFF
--- a/tests/chaos/network-delay.sh
+++ b/tests/chaos/network-delay.sh
@@ -21,8 +21,10 @@ NC='\033[0m'
 
 log_info() { echo -e "${CYAN}[INFO]${NC}  $*"; }
 log_ok()   { echo -e "${GREEN}[PASS]${NC}  $*"; }
-log_fail() { echo -e "${RED}[FAIL]${NC}  $*"; }
+log_fail() { echo -e "${RED}[FAIL]${NC}  $*"; FAILED=1; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+
+FAILED=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -41,6 +43,21 @@ check_endpoint() {
   local code
   code=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "$url" 2>/dev/null || echo "000")
   echo "$code"
+}
+
+check_http_code() {
+  local url="$1" expected="$2" desc="$3" token="$4"
+  local code
+  code=$(check_endpoint "$url" "$desc" "$token")
+  local matched=false
+  for e in $expected; do
+    [ "$code" = "$e" ] && matched=true
+  done
+  if $matched; then
+    log_ok "$desc — returned $code"
+  else
+    log_fail "$desc — returned $code (expected one of: $expected)"
+  fi
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────
@@ -101,18 +118,26 @@ log_info "  Baseline request took ~${BASELINE_MS}ms"
 echo ""
 log_info "Step 4: Injecting ${DELAY_MS}ms network delay to $POSTGRES_CONTAINER..."
 
+if ! docker exec "$POSTGRES_CONTAINER" sh -c "command -v tc" 2>/dev/null; then
+  log_info "Installing iproute2..."
+  docker exec "$POSTGRES_CONTAINER" apk add -q iproute2 2>/dev/null || true
+fi
+
 INJECT_RESULT=$(docker exec "$POSTGRES_CONTAINER" sh -c "
-  apk add -q iproute2 2>/dev/null || true
   tc qdisc add dev eth0 root netem delay ${DELAY_MS}ms ${JITTER_MS}ms 2>&1
 ") || true
 
 if echo "$INJECT_RESULT" | grep -q "RTNETLINK answers: File exists"; then
-  log_warn "Delay rule already exists, replacing..."
-  docker exec "$POSTGRES_CONTAINER" sh -c "tc qdisc replace dev eth0 root netem delay ${DELAY_MS}ms ${JITTER_MS}ms" 2>/dev/null || true
+  REPLACE_RESULT=$(docker exec "$POSTGRES_CONTAINER" sh -c "tc qdisc replace dev eth0 root netem delay ${DELAY_MS}ms ${JITTER_MS}ms" 2>&1) || true
+  if [ -z "$REPLACE_RESULT" ]; then
+    log_ok "Delay rule replaced"
+  else
+    log_fail "Failed to replace delay rule: $REPLACE_RESULT"
+  fi
 elif [ -z "$INJECT_RESULT" ]; then
   log_ok "Delay injected successfully"
 else
-  log_warn "Inject result: $INJECT_RESULT"
+  log_fail "Delay injection failed: $INJECT_RESULT"
 fi
 
 sleep 2
@@ -129,18 +154,8 @@ if [ -n "$TOKEN" ]; then
   log_info "  Request with delay took ~${TEST_MS}ms"
   log_info "  Response code: $DELAY_CODE"
 
-  if [ "$DELAY_CODE" = "200" ] || [ "$DELAY_CODE" = "401" ] || [ "$DELAY_CODE" = "403" ]; then
-    log_ok "Service handled increased latency gracefully (code: $DELAY_CODE)"
-  else
-    log_warn "Service returned $DELAY_CODE under delay"
-  fi
-
-  # Test another endpoint
-  DELAY_CODE2=$(check_endpoint "$API_GATEWAY/api/leave" "leave" "$TOKEN")
-  log_info "  Leave endpoint code under delay: $DELAY_CODE2"
-  if [ "$DELAY_CODE2" = "200" ] || [ "$DELAY_CODE2" = "401" ] || [ "$DELAY_CODE2" = "403" ]; then
-    log_ok "Leave service handled gracefully"
-  fi
+  check_http_code "$API_GATEWAY/api/employee/employees?page=1&page_size=1" "200 401 403" "Employee endpoint under delay" "$TOKEN"
+  check_http_code "$API_GATEWAY/api/leave" "200 401 403" "Leave endpoint under delay" "$TOKEN"
 fi
 
 sleep 2
@@ -148,8 +163,12 @@ sleep 2
 # 6. Remove delay
 echo ""
 log_info "Step 6: Removing network delay..."
-docker exec "$POSTGRES_CONTAINER" sh -c "tc qdisc del dev eth0 root netem 2>/dev/null" || true
-log_ok "Network delay removed"
+REMOVE_RESULT=$(docker exec "$POSTGRES_CONTAINER" sh -c "tc qdisc del dev eth0 root netem 2>&1") || true
+if [ -z "$REMOVE_RESULT" ] || echo "$REMOVE_RESULT" | grep -q "RTNETLINK answers: No such file"; then
+  log_ok "Network delay removed"
+else
+  log_fail "Failed to remove network delay: $REMOVE_RESULT"
+fi
 
 sleep 2
 
@@ -157,13 +176,11 @@ sleep 2
 echo ""
 log_info "Step 7: Verifying recovery after delay removal..."
 if [ -n "$TOKEN" ]; then
-  RECOVERY_CODE=$(check_endpoint "$API_GATEWAY/api/employee/employees?page=1&page_size=1" "employee" "$TOKEN")
-  RECOVERY_END=$(date +%s%N)
-  log_info "  Recovery response code: $RECOVERY_CODE"
-  log_ok "Services returned to normal behavior"
+  check_http_code "$API_GATEWAY/api/employee/employees?page=1&page_size=1" "200 401 403" "Recovery check" "$TOKEN"
 fi
 
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
 echo "   Chaos Test Complete"
 echo "═══════════════════════════════════════════════════════════════"
+exit $FAILED

--- a/tests/chaos/service-failure.sh
+++ b/tests/chaos/service-failure.sh
@@ -21,8 +21,10 @@ NC='\033[0m'
 
 log_info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
 log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*"; }
-log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
+log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; FAILED=1; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+
+FAILED=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -56,23 +58,30 @@ check_gateway_up() {
   return 1
 }
 
+check_http_code() {
+  local url="$1" expected="$2" desc="$3" token="$4"
+  local code
+  code=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "$url" || echo "000")
+  local matched=false
+  for e in $expected; do
+    [ "$code" = "$e" ] && matched=true
+  done
+  if $matched; then
+    log_ok "$desc — returned $code (expected)"
+  else
+    log_fail "$desc — returned $code (expected one of: $expected)"
+  fi
+}
+
 check_other_services() {
   local token="$1"
   local endpoints=(
     "$API_GATEWAY/api/employee/employees?page=1&page_size=1"
     "$API_GATEWAY/api/leave"
   )
-  local all_ok=true
   for ep in "${endpoints[@]}"; do
-    local code
-    code=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "$ep") || code=000
-    if [ "$code" = "200" ] || [ "$code" = "401" ] || [ "$code" = "403" ]; then
-      log_ok "Other service endpoint $ep returned $code (expected)"
-    else
-      log_warn "Other service endpoint $ep returned $code"
-    fi
+    check_http_code "$ep" "200 401 403" "Other service $ep" "$token"
   done
-  return 0
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────
@@ -110,12 +119,7 @@ sleep "$SLEEP_BETWEEN"
 echo ""
 log_info "Step 3: Verifying gateway returns 503 for $SERVICE_NAME..."
 FAILED_ENDPOINT="$API_GATEWAY/api/attendance"
-HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$FAILED_ENDPOINT" || echo "000")
-if [ "$HTTP_CODE" = "503" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "000" ]; then
-  log_ok "Gateway returned $HTTP_CODE for failed service (expected 503/502)"
-else
-  log_warn "Gateway returned $HTTP_CODE (expected 503/502)"
-fi
+check_http_code "$FAILED_ENDPOINT" "503 502 000" "Gateway for failed service" "$TOKEN"
 
 # 5. Verify other services remain available
 echo ""
@@ -141,14 +145,10 @@ sleep "$SLEEP_BETWEEN"
 # 7. Verify recovery
 echo ""
 log_info "Step 6: Verifying automatic recovery..."
-RECOVERY_CODE=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$FAILED_ENDPOINT" || echo "000")
-if [ "$RECOVERY_CODE" = "200" ] || [ "$RECOVERY_CODE" = "401" ] || [ "$RECOVERY_CODE" = "403" ]; then
-  log_ok "Service recovered — endpoint returned $RECOVERY_CODE"
-else
-  log_warn "Recovery status: endpoint returned $RECOVERY_CODE"
-fi
+check_http_code "$FAILED_ENDPOINT" "200 401 403" "Service recovery" "$TOKEN"
 
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
 echo "   Chaos Test Complete"
 echo "═══════════════════════════════════════════════════════════════"
+exit $FAILED


### PR DESCRIPTION
Closes #68

## Problem
Both chaos test scripts (\service-failure.sh\ and \
etwork-delay.sh\) always exited 0 because:
- All failures used \log_warn\ or were swallowed by \|| true\
- No failure counter or \exit 1\ was ever reached
- HTTP response codes were logged but never validated as pass/fail

## Fix
- Added \FAILED=0\ counter — \log_fail()\ now sets it to 1
- Added \check_http_code()\ helper that validates exact expected HTTP codes
- Replaced \log_warn\-only code paths with \log_fail\ + counter tracking
- Fixed delay injection/removal validation in \
etwork-delay.sh\ to detect actual failures
- Both scripts now \exit \\ at the end — CI will see non-zero exit on failure

## Files changed
- \	ests/chaos/service-failure.sh\ — 28 insertions, 16 deletions
- \	ests/chaos/network-delay.sh\ — 34 insertions, 29 deletions