### PR TITLE
fix: make PaginatedResponse generic with typed items to enable Pydantic validation

### DIFF
--- a/services/ats-service/routers/applications.py
+++ b/services/ats-service/routers/applications.py
@@ -10,7 +10,7 @@ import schemas
 router = APIRouter(tags=["applications"])
 
 
-@router.get("/applications", response_model=schemas.PaginatedResponse, summary="List applications")
+@router.get("/applications", response_model=schemas.ApplicationListResponse, summary="List applications")
 def list_applications(
         page: int = Query(
             1,

--- a/services/ats-service/routers/campus_recruitment.py
+++ b/services/ats-service/routers/campus_recruitment.py
@@ -8,7 +8,7 @@ import schemas
 router = APIRouter(tags=["campus-recruitment"])
 
 
-@router.get("/campus/drives", response_model=schemas.PaginatedResponse, summary="List campus drives")
+@router.get("/campus/drives", response_model=schemas.CampusDriveListResponse, summary="List campus drives")
 def list_drives(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
@@ -65,7 +65,7 @@ def delete_drive(
     return {"message": "Campus drive deleted successfully"}
 
 
-@router.get("/campus/registrations", response_model=schemas.PaginatedResponse, summary="List campus registrations")
+@router.get("/campus/registrations", response_model=schemas.CampusRegistrationListResponse, summary="List campus registrations")
 def list_registrations(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/routers/candidates.py
+++ b/services/ats-service/routers/candidates.py
@@ -10,7 +10,7 @@ import schemas
 router = APIRouter(tags=["candidates"])
 
 
-@router.get("/candidates", response_model=schemas.PaginatedResponse, summary="List candidates")
+@router.get("/candidates", response_model=schemas.CandidateListResponse, summary="List candidates")
 def list_candidates(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
@@ -73,7 +73,7 @@ def delete_candidate(
 
 
 @router.get("/candidates/{candidate_id}/applications",
-            response_model=schemas.PaginatedResponse,
+            response_model=schemas.ApplicationListResponse,
             summary="Get applications by candidate")
 def get_candidate_applications(
     candidate_id: str,

--- a/services/ats-service/routers/interviews.py
+++ b/services/ats-service/routers/interviews.py
@@ -11,7 +11,7 @@ import schemas
 router = APIRouter(tags=["interviews"])
 
 
-@router.get("/interviews", response_model=schemas.PaginatedResponse, summary="List interviews")
+@router.get("/interviews", response_model=schemas.InterviewListResponse, summary="List interviews")
 def list_interviews(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/routers/jobs.py
+++ b/services/ats-service/routers/jobs.py
@@ -10,7 +10,7 @@ import schemas
 router = APIRouter(tags=["jobs"])
 
 
-@router.get("/jobs", response_model=schemas.PaginatedResponse, summary="List jobs")
+@router.get("/jobs", response_model=schemas.JobListResponse, summary="List jobs")
 def list_jobs(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
@@ -93,7 +93,7 @@ def close_job(
 
 
 @router.get("/jobs/{job_id}/applications",
-            response_model=schemas.PaginatedResponse,
+            response_model=schemas.ApplicationListResponse,
             summary="Get applications for a job")
 def get_job_applications(
     job_id: str,

--- a/services/ats-service/routers/offer_letters.py
+++ b/services/ats-service/routers/offer_letters.py
@@ -7,7 +7,7 @@ import schemas
 router = APIRouter(tags=["offer-letters"])
 
 
-@router.get("/offer-templates", response_model=schemas.PaginatedResponse, summary="List offer templates")
+@router.get("/offer-templates", response_model=schemas.OfferTemplateListResponse, summary="List offer templates")
 def list_templates(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/routers/offers.py
+++ b/services/ats-service/routers/offers.py
@@ -10,7 +10,7 @@ import schemas
 router = APIRouter(tags=["offers"])
 
 
-@router.get("/offers", response_model=schemas.PaginatedResponse, summary="List offers")
+@router.get("/offers", response_model=schemas.OfferListResponse, summary="List offers")
 def list_offers(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/routers/referral_management.py
+++ b/services/ats-service/routers/referral_management.py
@@ -8,7 +8,7 @@ import schemas
 router = APIRouter(tags=["referral-management"])
 
 
-@router.get("/referrals", response_model=schemas.PaginatedResponse, summary="List referrals")
+@router.get("/referrals", response_model=schemas.ReferralListResponse, summary="List referrals")
 def list_referrals(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/routers/resume_parser.py
+++ b/services/ats-service/routers/resume_parser.py
@@ -49,7 +49,7 @@ def upload_resume(
     return resume
 
 
-@router.get("/resumes", response_model=schemas.PaginatedResponse, summary="List resumes")
+@router.get("/resumes", response_model=schemas.ResumeListResponse, summary="List resumes")
 def list_resumes(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),

--- a/services/ats-service/schemas.py
+++ b/services/ats-service/schemas.py
@@ -1,11 +1,13 @@
 from datetime import datetime, date
 from decimal import Decimal
-from typing import List, Optional
+from typing import Generic, List, Optional, TypeVar
 from pydantic import BaseModel, Field
 
+T = TypeVar("T")
 
-class PaginatedResponse(BaseModel):
-    items: List
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
     total: int
     page: int
     page_size: int
@@ -657,3 +659,16 @@ class HiringPipelineResponse(BaseModel):
     pipeline_stages: List[dict] = []
     upcoming_interviews: List[dict] = []
     recent_activities: List[dict] = []
+
+
+# Typed paginated response aliases
+JobListResponse = PaginatedResponse[JobResponse]
+CandidateListResponse = PaginatedResponse[CandidateResponse]
+ApplicationListResponse = PaginatedResponse[ApplicationListResponse]
+InterviewListResponse = PaginatedResponse[InterviewResponse]
+OfferListResponse = PaginatedResponse[OfferResponse]
+OfferTemplateListResponse = PaginatedResponse[OfferTemplateResponse]
+ResumeListResponse = PaginatedResponse[ResumeUploadResponse]
+ReferralListResponse = PaginatedResponse[ReferralResponse]
+CampusDriveListResponse = PaginatedResponse[CampusDriveResponse]
+CampusRegistrationListResponse = PaginatedResponse[CampusRegistrationResponse]

--- a/services/audit-compliance-service/schemas.py
+++ b/services/audit-compliance-service/schemas.py
@@ -1,8 +1,10 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+T = TypeVar("T")
 
 
 class AuditLogCreate(BaseModel):
@@ -45,16 +47,17 @@ class AuditLogResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class PaginatedResponse(BaseModel):
-    items: list
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
     total: int
     page: int
     page_size: int
     total_pages: int
 
 
-class AuditLogPaginated(PaginatedResponse):
-    items: list[AuditLogResponse]
+class AuditLogPaginated(PaginatedResponse[AuditLogResponse]):
+    pass
+
 
 
 class CompliancePolicyCreate(BaseModel):
@@ -121,8 +124,8 @@ class ComplianceViolationResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class ComplianceViolationPaginated(PaginatedResponse):
-    items: list[ComplianceViolationResponse]
+class ComplianceViolationPaginated(PaginatedResponse[ComplianceViolationResponse]):
+    pass
 
 
 class DataRetentionPolicyCreate(BaseModel):

--- a/services/employee-lifecycle-service/schemas.py
+++ b/services/employee-lifecycle-service/schemas.py
@@ -1,7 +1,9 @@
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 from uuid import UUID
 from pydantic import BaseModel, Field
+
+T = TypeVar("T")
 
 
 class HealthResponse(BaseModel):
@@ -14,11 +16,12 @@ class MessageResponse(BaseModel):
     message: str
 
 
-class PaginatedResponse(BaseModel):
-    items: list[Any]
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
     total: int
     page: int
     page_size: int
+    total_pages: int
 
 
 # ── Onboarding ───────────────────────────────────────────────────────

--- a/services/security-service/schemas.py
+++ b/services/security-service/schemas.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 from uuid import UUID
 from pydantic import BaseModel, Field
+
+T = TypeVar("T")
 
 class ZeroTrustPolicyCreate(BaseModel):
     tenant_id: str = Field(..., max_length=50)
@@ -254,24 +256,24 @@ class SessionRecordingResponse(BaseModel):
     ended_at: Optional[datetime]
     model_config = {"from_attributes": True}
 
-class PaginatedResponse(BaseModel):
-    items: list
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
     total: int
     page: int
     page_size: int
     total_pages: int
 
-class ZTAPaginated(PaginatedResponse):
-    items: list[ZeroTrustPolicyResponse]
+class ZTAPaginated(PaginatedResponse[ZeroTrustPolicyResponse]):
+    pass
 
-class CAPaginated(PaginatedResponse):
-    items: list[ConditionalAccessResponse]
+class CAPaginated(PaginatedResponse[ConditionalAccessResponse]):
+    pass
 
-class RiskPaginated(PaginatedResponse):
-    items: list[RiskAssessmentResponse]
+class RiskPaginated(PaginatedResponse[RiskAssessmentResponse]):
+    pass
 
-class DLPPaginated(PaginatedResponse):
-    items: list[DLPIncidentResponse]
+class DLPPaginated(PaginatedResponse[DLPIncidentResponse]):
+    pass
 
 class SecurityDashboard(BaseModel):
     zero_trust_policies: int

--- a/services/workforce-planning-service/schemas.py
+++ b/services/workforce-planning-service/schemas.py
@@ -1,18 +1,21 @@
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 from uuid import UUID
 from pydantic import BaseModel, Field
+
+T = TypeVar("T")
 
 
 class MessageResponse(BaseModel):
     message: str
 
 
-class PaginatedResponse(BaseModel):
-    items: list[Any]
+class PaginatedResponse(BaseModel, Generic[T]):
+    items: list[T]
     total: int
     page: int
     page_size: int
+    total_pages: int
 
 
 class DashboardResponse(BaseModel):


### PR DESCRIPTION
## Problem

PaginatedResponse used `items: list` or `items: list[Any]` (untyped), bypassing Pydantic's response validation. Type errors in items were not caught, and API clients could receive data that doesn't match expected types.

## Solution

Made PaginatedResponse a generic class using `BaseModel, Generic[T]` with `items: list[T]` in all 5 affected services:

- audit-compliance-service
- employee-lifecycle-service
- workforce-planning-service
- security-service
- ats-service

### Additional changes

- **audit-compliance-service**: Updated AuditLogPaginated and ComplianceViolationPaginated to inherit from typed generic
- **security-service**: Updated ZTAPaginated, CAPaginated, RiskPaginated, DLPPaginated to inherit from typed generic
- **ats-service**: Created typed list response aliases (JobListResponse, CandidateListResponse, etc.) and updated all 12 endpoint response models across 8 router files
- Added missing `total_pages` field to employee-lifecycle and workforce-planning PaginatedResponse