### PR TITLE
fix: chaos test uses dynamic endpoint instead of hardcoded attendance

### DIFF
--- a/tests/chaos/service-failure.sh
+++ b/tests/chaos/service-failure.sh
@@ -12,6 +12,30 @@ AUTH_URL="${AUTH_URL:-http://localhost:8010}"
 SLEEP_BETWEEN="${SLEEP_BETWEEN:-3}"
 MAX_RETRIES=12
 
+# ── Service-to-Endpoint Mapping ─────────────────────────────────────────────
+get_service_endpoint() {
+  local name="$1"
+  case "$name" in
+    attendance-service)          echo "/api/attendance" ;;
+    auth-service)                echo "/api/auth" ;;
+    employee-service)            echo "/api/employee" ;;
+    analytics-service)           echo "/api/analytics" ;;
+    notification-service)        echo "/api/notification" ;;
+    leave-service)               echo "/api/leave" ;;
+    payroll-service)             echo "/api/payroll" ;;
+    ats-service)                 echo "/api/ats" ;;
+    lms-service)                 echo "/api/lms" ;;
+    performance-service)         echo "/api/performance" ;;
+    ai-copilot-service)          echo "/api/copilot" ;;
+    audit-compliance-service)    echo "/api/audit" ;;
+    integration-service)         echo "/api/integration" ;;
+    employee-lifecycle-service)  echo "/api/lifecycle" ;;
+    security-service)            echo "/api/security" ;;
+    ai-service)                  echo "/api/ai" ;;
+    *)                           echo "" ;;
+  esac
+}
+
 # ── Colors ─────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -109,7 +133,12 @@ sleep "$SLEEP_BETWEEN"
 # 4. Verify the API gateway returns 503 for the failed service
 echo ""
 log_info "Step 3: Verifying gateway returns 503 for $SERVICE_NAME..."
-FAILED_ENDPOINT="$API_GATEWAY/api/attendance"
+SERVICE_PATH=$(get_service_endpoint "$SERVICE_NAME")
+if [ -z "$SERVICE_PATH" ]; then
+  log_fail "Unknown service '$SERVICE_NAME' — no API endpoint mapping available"
+  exit 1
+fi
+FAILED_ENDPOINT="$API_GATEWAY$SERVICE_PATH"
 HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" "$FAILED_ENDPOINT" || echo "000")
 if [ "$HTTP_CODE" = "503" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "000" ]; then
   log_ok "Gateway returned $HTTP_CODE for failed service (expected 503/502)"


### PR DESCRIPTION
## Summary

The chaos test script (\	ests/chaos/service-failure.sh\) hardcoded \/api/attendance\ on line 112 regardless of which \SERVICE_NAME\ argument was passed. If testing \employee-service\ failure, the test still checked \/api/attendance\, making the service failure validation incorrect for any service except attendance.

## Change

Added a \get_service_endpoint()\ function that maps each service name to its correct API gateway path using the actual route definitions from the API gateway:

| Service Name | API Endpoint |
|---|---|
| attendance-service | /api/attendance |
| employee-service | /api/employee |
| leave-service | /api/leave |
| payroll-service | /api/payroll |
| performance-service | /api/performance |
| auth-service | /api/auth |
| analytics-service | /api/analytics |
| notification-service | /api/notification |
| ats-service | /api/ats |
| lms-service | /api/lms |
| ai-copilot-service | /api/copilot |
| audit-compliance-service | /api/audit |
| integration-service | /api/integration |
| employee-lifecycle-service | /api/lifecycle |
| security-service | /api/security |
| ai-service | /api/ai |

The function returns an empty string for unknown services, causing the script to exit with a clear error message instead of silently testing the wrong endpoint.

## Impact
- Service failure validation now checks the correct endpoint for every service
- Unknown services produce a clear error instead of incorrect test results
- Backward compatible - all existing usage continues to work

Closes #61