### PR TITLE
fix: remove ambiguous numeric 'id' from Employee type

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,7 +18,6 @@ export interface AuthResponse {
 
 export interface Employee {
   _id?: string;
-  id?: number;
   name: string;
   department: string;
   position: string;


### PR DESCRIPTION
## Summary

The \Employee\ type in \rontend/src/types/index.ts\ had both \_id\ (MongoDB string) and \id\ (number) declared as optional fields, creating ambiguity about which identifier to use in API calls (#62).

## Changes

- **Removed \id?: number\** — This numeric ID has no backend counterpart. The \employee-python-service\ model uses MongoDB ObjectId (\_id\) and the Pydantic schema aliases it to \id\ as a **string**, not a number. The field was never referenced anywhere in frontend code.
- **Kept \_id?: string\** — The backend returns the MongoDB ObjectId as a string in all API responses. It remains optional to accommodate creation scenarios where \_id\ is assigned by the database.

## Context

All employee CRUD API routes (\GET\, \PUT\, \DELETE\) use \email\ as the unique lookup key. Neither \_id\ nor the removed numeric \id\ is passed to any API endpoint. The effective identifier throughout the codebase is \email\.

## Verification

- \grep\ across \rontend/src\ confirmed zero usages of \employee.id\ or \emp.id\
- Backend \employee-python-service/main.py\ confirmed no numeric \id\ field exists
- Existing tests pass without changes needed