### PR TITLE
fix: make Prometheus alert rules runtime-agnostic and add comprehensive production alerts

### DIFF
--- a/alert.rules.yml
+++ b/alert.rules.yml
@@ -11,7 +11,7 @@ groups:
           description: "{{ $labels.job }} has been unreachable for more than 30 seconds."
 
       - alert: HighErrorRate
-        expr: rate(http_requests_total{status=~"5.."}[5m]) > 0.05
+        expr: sum by (job) (rate(atlas_http_requests_total{status_code=~"5[0-9][0-9]"}[5m])) / sum by (job) (rate(atlas_http_requests_total[5m])) > 0.05
         for: 1m
         labels:
           severity: warning
@@ -19,11 +19,94 @@ groups:
           summary: "High error rate on {{ $labels.job }}"
           description: "Error rate on {{ $labels.job }} is {{ $value | humanizePercentage }}"
 
-      - alert: HighMemoryUsage
-        expr: process_resident_memory_bytes / process_virtual_memory_bytes > 0.9
+      - alert: HighLatencyP99
+        expr: histogram_quantile(0.99, sum by (job, le) (rate(atlas_http_request_duration_seconds_bucket[5m]))) > 1.0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "High memory usage on {{ $labels.job }}"
-          description: "{{ $labels.job }} memory usage is above 90%"
+          summary: "High p99 latency on {{ $labels.job }}"
+          description: "p99 latency on {{ $labels.job }} is {{ $value | humanizeDuration }}"
+
+      - alert: HighLatencyP99Critical
+        expr: histogram_quantile(0.99, sum by (job, le) (rate(atlas_http_request_duration_seconds_bucket[5m]))) > 2.5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical p99 latency on {{ $labels.job }}"
+          description: "p99 latency on {{ $labels.job }} is {{ $value | humanizeDuration }}"
+
+      - alert: HighInProgressRequests
+        expr: sum by (job) (atlas_http_requests_in_progress) > 100
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High in-flight requests on {{ $labels.job }}"
+          description: "{{ $labels.job }} has {{ $value }} requests in progress"
+
+  - name: atlas_infrastructure
+    rules:
+      - alert: DiskSpaceWarning
+        expr: (node_filesystem_avail_bytes{fstype!="tmpfs"} / node_filesystem_size_bytes{fstype!="tmpfs"}) < 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk space low on {{ $labels.device }}"
+          description: "Disk space on {{ $labels.device }} ({{ $labels.mountpoint }}) is {{ $value | humanizePercentage }} available"
+
+      - alert: DiskSpaceCritical
+        expr: (node_filesystem_avail_bytes{fstype!="tmpfs"} / node_filesystem_size_bytes{fstype!="tmpfs"}) < 0.05
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk space critical on {{ $labels.device }}"
+          description: "Disk space on {{ $labels.device }} ({{ $labels.mountpoint }}) is {{ $value | humanizePercentage }} available"
+
+      - alert: NodeMemoryUsageWarning
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Node memory usage above 90%"
+          description: "Memory usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}"
+
+      - alert: NodeMemoryUsageCritical
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Node memory usage above 95%"
+          description: "Memory usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}"
+
+      - alert: NodeCPUUsageHigh
+        expr: (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) > 0.8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CPU usage above 80% on {{ $labels.instance }}"
+          description: "CPU usage on {{ $labels.instance }} is {{ $value | humanizePercentage }}"
+
+      - alert: TLSCertExpiryWarning
+        expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 30
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS certificate expires in {{ $value | humanizeDuration }}"
+          description: "TLS certificate for {{ $labels.target }} expires in {{ $value | humanizeDuration }}"
+
+      - alert: TLSCertExpiryCritical
+        expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 7
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS certificate expires in {{ $value | humanizeDuration }}"
+          description: "TLS certificate for {{ $labels.target }} expires in less than 7 days"


### PR DESCRIPTION
## Summary

Fixes #60 by replacing Go-only Prometheus metrics (`http_requests_total`, `process_resident_memory_bytes`) with runtime-agnostic alternatives and expanding from 3 to 12 production-grade alert rules.

## Changes

### Bugs Fixed
- **HighErrorRate**: Replaced `http_requests_total{status=~"5.."}` (Go-only, doesn't exist in Node.js/Python) with `atlas_http_requests_total{status_code=~"5[0-9][0-9]"}` — the actual metric name exposed by Python services via the `atlas_observability` library. Also changed from raw error rate to error percentage (errors/total requests).
- **HighMemoryUsage**: Removed `process_resident_memory_bytes / process_virtual_memory_bytes` (Go runtime metrics, not available in Node.js, Python, or Java). Replaced with node-level memory alerts using `node_memory_*` metrics.

### New Alerts Added

| Alert | Metric Source | Severity | Description |
|---|---|---|---|
| HighLatencyP99 | atlas_http_request_duration_seconds | warning | p99 latency > 1s for 5m |
| HighLatencyP99Critical | atlas_http_request_duration_seconds | critical | p99 latency > 2.5s for 5m |
| HighInProgressRequests | atlas_http_requests_in_progress | warning | > 100 concurrent requests |
| DiskSpaceWarning | node_filesystem_* | warning | < 10% free for 5m |
| DiskSpaceCritical | node_filesystem_* | critical | < 5% free for 1m |
| NodeMemoryUsageWarning | node_memory_* | warning | > 90% used for 5m |
| NodeMemoryUsageCritical | node_memory_* | critical | > 95% used for 2m |
| NodeCPUUsageHigh | node_cpu_seconds_total | warning | > 80% CPU for 10m |
| TLSCertExpiryWarning | probe_ssl_earliest_cert_expiry | warning | Expires < 30 days |
| TLSCertExpiryCritical | probe_ssl_earliest_cert_expiry | critical | Expires < 7 days |

## Runtime Compatibility

- `atlas_*` metrics are exposed by 11 Python services via the `atlas_observability` library
- `node_*` metrics require `node_exporter` to be added to the monitoring stack
- `probe_ssl_*` metrics require `blackbox_exporter` to be added to the monitoring stack

## Prerequisites

- For disk space, memory, and CPU alerts: add `node_exporter` to `docker-compose.monitoring.yml`
- For TLS certificate alerts: add `blackbox_exporter` to `docker-compose.monitoring.yml`
