### PR TITLE
fix: remove external network dependency from monitoring stack

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -49,4 +49,4 @@ volumes:
 
 networks:
   atlas-network:
-    external: true
+    driver: bridge


### PR DESCRIPTION
## Description

The monitoring stack's Docker network (\tlas-network\) was declared with \external: true\, requiring the network to already exist before deployment. This caused the monitoring stack to fail if deployed independently or before the main stack.

## Change

Changed the network definition in \docker-compose.monitoring.yml\ from:
\\\yaml
networks:
  atlas-network:
    external: true
\\\
to:
\\\yaml
networks:
  atlas-network:
    driver: bridge
\\\

## Impact

- Monitoring stack can now be deployed independently without requiring the main stack to be started first
- If \tlas-network\ already exists (created by main stack), Docker Compose will silently use it
- If the network does not exist, Docker Compose will automatically create it
- Consistent with how the network is defined in \docker-compose.yml\
- No breaking changes to existing workflows

Fixes #58