### PR TITLE
fix: add persistent volumes for Redis, RabbitMQ, Zookeeper, and Kafka

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     user: "1001:1001"
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
     networks:
       - atlas-network
 
@@ -58,6 +60,8 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
     networks:
       - atlas-network
 
@@ -69,6 +73,9 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
     ports:
       - "2181:2181"
+    volumes:
+      - zookeeper_data:/var/lib/zookeeper/data
+      - zookeeper_log:/var/lib/zookeeper/log
     networks:
       - atlas-network
 
@@ -87,6 +94,8 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka_data:/var/lib/kafka/data
     networks:
       - atlas-network
 
@@ -415,3 +424,8 @@ networks:
 volumes:
   atlas_postgres_data:
   mongo_data:
+  redis_data:
+  rabbitmq_data:
+  zookeeper_data:
+  zookeeper_log:
+  kafka_data:


### PR DESCRIPTION
## Description

Docker Compose only defined persistent volumes for Postgres and MongoDB. Redis, RabbitMQ, Zookeeper, and Kafka had no volumes, causing session cache, message queues, stream data, and coordination state to be lost on container restart.

## Changes

Added Docker named volumes for the following services:

| Service    | Volume               | Mount Path                  |
|------------|----------------------|-----------------------------|
| Redis      | \edis_data\        | \/data\                    |
| RabbitMQ   | \abbitmq_data\     | \/var/lib/rabbitmq\        |
| Zookeeper  | \zookeeper_data\    | \/var/lib/zookeeper/data\  |
| Zookeeper  | \zookeeper_log\     | \/var/lib/zookeeper/log\   |
| Kafka      | \kafka_data\        | \/var/lib/kafka/data\      |

All volumes use the default \local\ driver and are declared in the top-level \olumes:\ section alongside the existing \tlas_postgres_data\ and \mongo_data\ volumes.

## Impact

- Redis cache, RabbitMQ queues, Kafka streams, and Zookeeper state now persist across container restarts
- No breaking changes to existing workflows
- No manual volume cleanup needed on \docker-compose down -v\

Fixes #57