### PR TITLE
fix: remove ambiguous _id and id fields from Employee type

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -17,8 +17,6 @@ export interface AuthResponse {
 }
 
 export interface Employee {
-  _id?: string;
-  id?: number;
   name: string;
   department: string;
   position: string;


### PR DESCRIPTION
## Summary

Fixes #62 — The `Employee` interface had both `_id?: string` (MongoDB-style) and `id?: number` declared as optional fields, creating ambiguity about which identifier to use in API calls.

## Root Cause

The Employee type in `frontend/src/types/index.ts` defined two optional ID fields without any guidance on which to use:
```typescript
export interface Employee {
  _id?: string;
  id?: number;
  ...
}
```

## Investigation

A thorough search of the entire frontend TypeScript/TSX codebase confirmed that **neither `_id` nor `id` was ever accessed** on Employee-typed objects. The codebase uses `email` (string) as the sole employee identifier:

- **API calls:** `/employee/employees/${email}` for get/update/delete
- **Frontend routing:** `/dashboard/employees/${encodeURIComponent(emp.email)}`
- **React keys:** `key={emp.email}`

Other modules (leave, payroll, attendance, lifecycle, L&D) pass `employeeId` as a string — sourced from email or user input — not from `Employee.id` or `Employee._id`.

## Fix

Removed both `_id` and `id` from the `Employee` interface. This:
- Eliminates the ambiguity about which ID to use
- Makes TypeScript catch any undefined ID usage at compile time (both were optional)
- Aligns the type with actual usage across the entire codebase
