### PR TITLE
fix: make test actually fails when tests fail instead of always exiting 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,19 @@ clean:
 
 test:
 	@echo "Running all backend tests..."
-	cd services/api-gateway-node && npm test || true
-	cd services/auth-service && npm test || true
-	cd services/employee-python-service && python -m pytest -v || true
-	cd services/analytics-python-service && python -m pytest -v || true
-	cd services/payroll-java-service && mvn test || true
-	cd services/leave-service && mvn test || true
-	@echo "All backend tests completed."
+	@failed=0; \
+	cd services/api-gateway-node && npm test || failed=1; \
+	cd services/auth-service && npm test || failed=1; \
+	cd services/employee-python-service && python -m pytest -v || failed=1; \
+	cd services/analytics-python-service && python -m pytest -v || failed=1; \
+	cd services/payroll-java-service && mvn test || failed=1; \
+	cd services/leave-service && mvn test || failed=1; \
+	if [ $$failed -ne 0 ]; then \
+		echo ""; \
+		echo "FAILURE: Some backend tests failed."; \
+		exit 1; \
+	fi; \
+	echo "All backend tests completed."
 
 test-e2e:
 	@echo "Running Playwright End-to-End test suite..."


### PR DESCRIPTION
Closes #53

## What was wrong

Every test command in the \make test\ target used \|| true\, so the target always exited with code 0. This meant:
- CI pipelines always showed green regardless of test failures
- Developers running make test locally saw red output but the command still succeeded
- Regressions could be introduced and deployed without detection

## What changed

The fix replaces \|| true\ with a shell variable that tracks failures across all services:

\\\makefile
@failed=0; \
cd services/api-gateway-node && npm test || failed=1; \
...
if [ failed -ne 0 ]; then exit 1; fi;
\\\

This runs every service's test suite regardless of individual failures, then exits with code 1 if any test failed. No more silent swallowing of failures.

## Why not just remove || true

Simply dropping \|| true\ would make make abort at the first failing service and skip the rest. The chosen approach runs all tests and reports the overall result, which is more useful for developers iterating on multiple services.