### PR TITLE
fix: tighten audit log count assertion in integration test

### DIFF
--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -399,10 +399,12 @@ TESTS+=("Query audit logs")
 AUDIT_LOGS=$(curl -sf "$AUDIT_SERVICE_URL/api/v1/audit/logs?page=1&page_size=5" \
   -H "X-Internal-Key: $AUDIT_KEY") || AUDIT_LOGS=""
 AUDIT_COUNT=$(echo "$AUDIT_LOGS" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('items',d.get('results',[]))))" 2>/dev/null) || AUDIT_COUNT="0"
-if [ "$AUDIT_COUNT" -ge 0 ] 2>/dev/null; then
-  report_pass "Query audit logs ($AUDIT_COUNT entries)"
+if [ "$AUDIT_COUNT" -gt 0 ]; then
+  echo "  ${GREEN}PASS${NC}  Found $AUDIT_COUNT audit log entries"
+  PASS=$((PASS + 1))
 else
-  report_fail "Query audit logs"
+  echo "  ${RED}FAIL${NC}  No audit log entries found (expected at least 1)"
+  exit 1
 fi
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #51 -- The audit log count assertion used `-ge 0`, which can never fail because every non-negative integer (including 0) satisfies it. Combined with `2>/dev/null`, even a completely empty or failed response would silently pass.

## Root Cause

Line 402 in `run-integration-tests.sh`:

```bash
if [ "$AUDIT_COUNT" -ge 0 ] 2>/dev/null; then
```

Three problems:
1. `-ge 0` is always true for any non-negative integer (0, 1, 42, etc.)
2. `2>/dev/null` hides bash errors if `$AUDIT_COUNT` is empty or not a number
3. On parse failure, `AUDIT_COUNT` defaults to `"0"`, which still satisfies `-ge 0`

The assertion was mathematically incapable of failing.

## Changes

| Before | After |
|---|---|
| `-ge 0` | `-gt 0` (requires at least 1 entry) |
| `2>/dev/null` suppressed errors | Removed to surface parse failures |
| `report_fail` (soft failure, test continues) | `exit 1` (hard failure, stops the suite) |
| Generic pass/fail message | Clear message showing actual count |

The integration test suite will now correctly fail if the audit service stops recording logs, preventing silent audit compliance gaps.
