### PR TITLE
fix: replace no-op assertions in Playwright E2E tests

### DIFF
--- a/frontend/tests/e2e/compliance.spec.ts
+++ b/frontend/tests/e2e/compliance.spec.ts
@@ -19,11 +19,9 @@ test.describe('Compliance Dashboard', () => {
     await expect(page.locator('h1')).toContainText(/compliance|Compliance/i);
 
     const auditLink = page.locator('a:has-text("Audit"), button:has-text("Audit")').first();
-    if (await auditLink.isVisible()) {
-      await auditLink.click();
-    }
-
-    await expect(page).toHaveURL(/.*audit.*|.*compliance.*/i);
+    await auditLink.waitFor({ state: 'visible', timeout: 5000 });
+    await auditLink.click();
+    await expect(page).toHaveURL(/.*audit.*/i);
   });
 
   test('check compliance policies', async ({ page }) => {
@@ -32,10 +30,8 @@ test.describe('Compliance Dashboard', () => {
     const policiesLink = page.locator(
       'a:has-text("Policy"), a:has-text("Policies"), button:has-text("Policy"), button:has-text("Policies")'
     ).first();
-    if (await policiesLink.isVisible()) {
-      await policiesLink.click();
-    }
-
-    await expect(page).toHaveURL(/.*policy.*|.*compliance.*/i);
+    await policiesLink.waitFor({ state: 'visible', timeout: 5000 });
+    await policiesLink.click();
+    await expect(page).toHaveURL(/.*policies.*|.*policy.*/i);
   });
 });

--- a/frontend/tests/e2e/lms-workflow.spec.ts
+++ b/frontend/tests/e2e/lms-workflow.spec.ts
@@ -21,7 +21,7 @@ test.describe('LMS Workflow', () => {
 
     const courseCards = page.locator('a[href*="/dashboard/lms/courses/"]');
     const count = await courseCards.count();
-    expect(count).toBeGreaterThanOrEqual(0);
+    expect(count).toBeGreaterThan(0);
   });
 
   test('enroll in a course', async ({ page }) => {
@@ -29,10 +29,9 @@ test.describe('LMS Workflow', () => {
     await expect(page.locator('h1')).toContainText('Courses');
 
     const enrollButton = page.locator('button:has-text("Enroll"), a:has-text("Enroll")').first();
-    if (await enrollButton.isVisible()) {
-      await enrollButton.click();
-      await expect(page.getByText(/enrolled|Enrolled|successfully/i)).toBeVisible();
-    }
+    await enrollButton.waitFor({ state: 'visible', timeout: 5000 });
+    await enrollButton.click();
+    await expect(page.getByText(/enrolled|Enrolled|successfully/i)).toBeVisible();
 
     await page.goto('/dashboard/lms');
     await expect(page.locator('h1')).toContainText('Learning Management');


### PR DESCRIPTION
Three Playwright E2E tests had assertions that could never fail, giving false confidence in CI and letting regressions slip through undetected.

### Changes

**1. Course catalog count (lms-workflow.spec.ts)**
Changed expect(count).toBeGreaterThanOrEqual(0) to expect(count).toBeGreaterThan(0). An empty page with zero course cards would have passed the old assertion. Now it correctly fails if no courses are rendered.

**2. Enrollment test (lms-workflow.spec.ts)**
Removed the if (await enrollButton.isVisible()) guard that let the test silently pass when the enroll button was missing. Replaced with wait enrollButton.waitFor({ state: 'visible', timeout: 5000 }) so the test fails with a clear timeout if no enroll button exists on the page.

**3. Compliance URL assertions (compliance.spec.ts)**
- Removed the if (isVisible()) guards from both compliance tests (same no-op pattern as the enrollment test).
- Changed expect(page).toHaveURL(/.*audit.*|.*compliance.*/i) to expect(page).toHaveURL(/.*audit.*/i) -- the old pattern matched /dashboard/compliance before any click happened.
- Changed expect(page).toHaveURL(/.*policy.*|.*compliance.*/i) to expect(page).toHaveURL(/.*policies.*|.*policy.*/i) -- same issue, removed the compliance fallback.

Fixes #52