### PR TITLE
fix: integration token refresh test reads cookie instead of JSON body

### DIFF
--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -96,14 +96,16 @@ else
   fi
 fi
 
+COOKIE_JAR=$(mktemp)
+
 TESTS+=("Login with valid credentials")
 LOGIN_RES=$(curl -sf -X POST "$AUTH_URL/login" \
   -H 'Content-Type: application/json' \
+  -c "$COOKIE_JAR" \
   -d '{"email":"admin@atlas.io","password":"ChangeMe123!"}') || { report_fail "Login with valid credentials"; LOGIN_RES=""; }
 
 if [ -n "$LOGIN_RES" ]; then
   TOKEN=$(echo "$LOGIN_RES" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) || TOKEN=""
-  REFRESH_TOKEN=$(echo "$LOGIN_RES" | python3 -c "import sys,json; print(json.load(sys.stdin)['refreshToken'])" 2>/dev/null) || REFRESH_TOKEN=""
   USER_ID=$(echo "$LOGIN_RES" | python3 -c "import sys,json; print(json.load(sys.stdin)['user']['id'])" 2>/dev/null) || USER_ID=""
   if [ -n "$TOKEN" ]; then
     report_pass "Login with valid credentials"
@@ -125,10 +127,11 @@ else
 fi
 
 TESTS+=("Token refresh")
-if [ -n "$REFRESH_TOKEN" ]; then
+if [ -s "$COOKIE_JAR" ] && grep -q "refreshToken" "$COOKIE_JAR" 2>/dev/null; then
   REFRESH_RES=$(curl -sf -X POST "$AUTH_URL/refresh" \
     -H 'Content-Type: application/json' \
-    -d "{\"refreshToken\":\"$REFRESH_TOKEN\"}") || REFRESH_RES=""
+    -b "$COOKIE_JAR" \
+    -c "$COOKIE_JAR") || REFRESH_RES=""
   NEW_TOKEN=$(echo "$REFRESH_RES" | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) || NEW_TOKEN=""
   if [ -n "$NEW_TOKEN" ]; then
     report_pass "Token refresh"
@@ -137,8 +140,10 @@ if [ -n "$REFRESH_TOKEN" ]; then
     report_fail "Token refresh"
   fi
 else
-  report_fail "Token refresh — no refresh token"
+  report_fail "Token refresh — no refresh token cookie"
 fi
+
+rm -f "$COOKIE_JAR"
 
 # ────────────────────────────────────────────────────────────────────────────
 #  3. Employee CRUD Flow


### PR DESCRIPTION
Closes #55

## Problem

The integration test assumed the refresh token was returned in the login JSON response body. But the auth service sets it as an httpOnly cookie (auth-service/index.js:713-718) and the /refresh endpoint reads from req.cookies (auth-service/index.js:744).

Lines 106 and 129-131 of run-integration-tests.sh:
- Line 106 tried to extract refreshToken from the JSON body, which returned empty
- Lines 129-131 sent the (empty) token as a JSON POST body
- The || REFRESH_TOKEN="" on line 106 silently swallowed the failure
- The test always fell through to "Token refresh - no refresh token"

## Fix

- Added curl -c cookie jar to the login request to capture the Set-Cookie header
- Removed the broken JSON body extraction of refreshToken (it was never in the JSON)
- Changed the refresh request to use curl -b to send the stored cookie
- Also passes -c to refresh to capture the rotated refreshToken cookie
- Cleans up the temp cookie jar file after the test

## Testing

The token refresh test now:
1. Logs in and stores the refreshToken cookie via curl -c
2. Checks the cookie jar actually contains refreshToken before proceeding
3. Sends the cookie back on the /refresh call via curl -b
4. Extracts the new token from the response JSON and continues with it
