### PR TITLE
fix: resolve race condition in token refresh interceptor (#20)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,8 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    original._retry = true;
+
     if (refreshPromise) {
       const token = await refreshPromise;
       if (token) {
@@ -68,7 +70,6 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    original._retry = true;
     refreshPromise = axios
       .post(`${API_BASE}/auth/refresh`, {}, { withCredentials: true })
       .then(({ data }) => {


### PR DESCRIPTION
## Description

Moves the original._retry = true flag before the efreshPromise check in the axios response interceptor to fix a race condition when multiple requests receive 401 simultaneously.

## Root Cause

When two API calls get a 401 at the same time:
- Request A enters the interceptor, finds no refreshPromise, sets _retry = true, creates refreshPromise
- Request B enters the interceptor, finds refreshPromise exists, awaits it, gets the token, retries
- Request B's _retry was never set to true
- If the retry also returns 401, Request B enters the interceptor again with _retry still undefined
- This causes the retry to attempt a new refresh, creating a loop

## Changes

- Moved original._retry = true before the refreshPromise check in rontend/src/lib/api.ts
- Both the initial request and concurrent requests now properly mark themselves as retried

## Testing

Existing refresh flow continues to work. The fix prevents the infinite loop scenario under concurrent 401 conditions.

Fixes #20