### PR TITLE
fix: add Bearer token support to WebSocket authentication (#24)

### DIFF
--- a/services/live-service/main.py
+++ b/services/live-service/main.py
@@ -520,7 +520,9 @@ async def sse_executive(request: Request): return await sse_channel("executive",
 
 async def verify_ws_token(websocket: WebSocket, token: Optional[str] = None) -> bool:
     auth_header = websocket.headers.get("x-internal-auth")
-    token_str = token or auth_header
+    bearer_header = websocket.headers.get("authorization", "")
+    bearer_token = bearer_header.removeprefix("Bearer ").strip() if bearer_header else None
+    token_str = token or auth_header or bearer_token
     if not token_str:
         await websocket.close(code=4001, reason="Missing authentication token")
         return False


### PR DESCRIPTION
## Description

Extends the WebSocket authentication in the Live Service to support the Authorization Bearer token header, in addition to the existing query parameter and x-internal-auth header.

## Changes

- Added Bearer token extraction from the Authorization header in verify_ws_token
- WebSocket connections can now authenticate via any of three methods: query ?token=, x-internal-auth header, or Authorization: Bearer header
- Token expiration and signature validation remain unchanged

## Context

The WebSocket endpoints already had authentication via the verify_ws_token function, which checked the query parameter and x-internal-auth header. This change adds support for the standard Authorization: Bearer header pattern for WebSocket upgrade requests, making authentication consistent with the REST API pattern.

Fixes #24