### PR TITLE
fix: add integration-service to CI with syntax check (#26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [employee-python-service, analytics-python-service]
+        service: [employee-python-service, analytics-python-service, integration-service]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -121,6 +121,9 @@ jobs:
         working-directory: services/${{ matrix.service }}
       - name: Install linting tools
         run: pip install flake8 pytest httpx bandit
+        working-directory: services/${{ matrix.service }}
+      - name: Syntax check
+        run: python -m py_compile main.py
         working-directory: services/${{ matrix.service }}
       - name: Lint Python
         run: flake8 . --max-line-length=120
@@ -141,8 +144,12 @@ jobs:
             echo "POSTGRES_USER=test" >> $GITHUB_ENV
             echo "POSTGRES_PASSWORD=test" >> $GITHUB_ENV
             echo "INTERNAL_JWT_SECRET=test-secret" >> $GITHUB_ENV
+          elif [[ "${{ matrix.service }}" == "integration-service" ]]; then
+            echo "INTERNAL_API_KEY=test-key" >> $GITHUB_ENV
+            echo "DATABASE_URL=sqlite:///test.db" >> $GITHUB_ENV
           fi
       - name: Test Python
+        if: hashFiles(format('services/{0}/test_*.py', matrix.service)) != '' || hashFiles(format('services/{0}/tests/**', matrix.service)) != ''
         run: pytest -v
         working-directory: services/${{ matrix.service }}
 


### PR DESCRIPTION
## Description

Prevents orphaned/indented code blocks from reaching production by adding the integration-service to the Python services CI matrix with a mandatory syntax compilation step.

## Changes

- Added integration-service to the Python services CI matrix
- Added a `python -m py_compile main.py` syntax check step for all Python services
- Added test environment variables for the integration service
- Made the pytest step conditional on test files existing

## Why

The integration service previously had no CI coverage. An indented orphaned code block (issue #26) could have caused an IndentationError at module load time, making the service completely non-functional. The py_compile step catches these errors before code reaches production.

Fixes #26
