### PR TITLE
fix: replace string-concatenated JSON with Jackson ObjectMapper in Java outbox events (#32)

### DIFF
--- a/services/payroll-java-service/src/main/java/com/ems/payroll/PayrollService.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/PayrollService.java
@@ -2,14 +2,19 @@ package com.ems.payroll;
 
 import com.ems.payroll.model.OutboxEvent;
 import com.ems.payroll.repository.OutboxEventRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class PayrollService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final PayrollRepository repository;
     private final OutboxEventRepository outboxEventRepository;
@@ -58,7 +63,17 @@ public class PayrollService {
             outboxEvent.setAggregateType("payroll");
             outboxEvent.setAggregateId(String.valueOf(record.getId()));
             outboxEvent.setEventType("PAYROLL_PROCESSED");
-            outboxEvent.setPayload("{\"payrollId\":" + record.getId() + ",\"employeeId\":\"" + employeeId + "\",\"period\":\"" + period + "\",\"grossAmount\":" + grossSalary + ",\"netAmount\":" + netSalary + ",\"currency\":\"USD\",\"status\":\"PROCESSED\",\"timestamp\":\"" + LocalDateTime.now() + "\",\"tenantId\":\"" + tenantId + "\"}");
+            outboxEvent.setPayload(toJson(Map.of(
+                "payrollId", record.getId(),
+                "employeeId", employeeId,
+                "period", period,
+                "grossAmount", grossSalary,
+                "netAmount", netSalary,
+                "currency", "USD",
+                "status", "PROCESSED",
+                "timestamp", LocalDateTime.now().toString(),
+                "tenantId", tenantId
+            )));
             outboxEvent.setStatus("PENDING");
             outboxEvent.setRetryCount(0);
             outboxEvent.setCreatedAt(LocalDateTime.now());
@@ -70,7 +85,13 @@ public class PayrollService {
             outboxEvent.setAggregateType("payroll");
             outboxEvent.setAggregateId("0");
             outboxEvent.setEventType("PAYROLL_FAILED");
-            outboxEvent.setPayload("{\"employeeId\":\"" + employeeId + "\",\"period\":\"" + period + "\",\"error\":\"" + e.getMessage() + "\",\"timestamp\":\"" + LocalDateTime.now() + "\",\"tenantId\":\"" + tenantId + "\"}");
+            outboxEvent.setPayload(toJson(Map.of(
+                "employeeId", employeeId,
+                "period", period,
+                "error", e.getMessage(),
+                "timestamp", LocalDateTime.now().toString(),
+                "tenantId", tenantId
+            )));
             outboxEvent.setStatus("PENDING");
             outboxEvent.setRetryCount(0);
             outboxEvent.setCreatedAt(LocalDateTime.now());
@@ -85,5 +106,13 @@ public class PayrollService {
         if (grossSalary <= 7000) return (grossSalary - 3000) * 0.15;
         if (grossSalary <= 12000) return (4000 * 0.15) + ((grossSalary - 7000) * 0.25);
         return (4000 * 0.15) + (5000 * 0.25) + ((grossSalary - 12000) * 0.35);
+    }
+
+    private static String toJson(Map<String, Object> payload) {
+        try {
+            return MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize outbox payload", e);
+        }
     }
 }

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/service/PayrollCompensationService.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/service/PayrollCompensationService.java
@@ -6,6 +6,8 @@ import com.ems.payroll.model.PayrollAudit;
 import com.ems.payroll.repository.EnhancedPayrollRepository;
 import com.ems.payroll.repository.OutboxEventRepository;
 import com.ems.payroll.repository.PayrollAuditRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,8 @@ import java.util.Map;
 
 @Service
 public class PayrollCompensationService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final EnhancedPayrollRepository payrollRepo;
     private final OutboxEventRepository outboxEventRepository;
@@ -51,7 +55,7 @@ public class PayrollCompensationService {
         compensationEvent.setAggregateType("payroll");
         compensationEvent.setAggregateId(payrollId);
         compensationEvent.setEventType("PAYROLL_COMPENSATED");
-        compensationEvent.setPayload("{\"payrollId\":\"" + payrollId + "\",\"reason\":\"" + reason + "\"}");
+        compensationEvent.setPayload(toJson(Map.of("payrollId", payrollId, "reason", reason)));
         compensationEvent.setStatus("PENDING");
         compensationEvent.setRetryCount(0);
         compensationEvent.setCreatedAt(LocalDateTime.now());
@@ -64,10 +68,18 @@ public class PayrollCompensationService {
         failureEvent.setAggregateType("payroll");
         failureEvent.setAggregateId(payrollId);
         failureEvent.setEventType("PAYROLL_FAILED");
-        failureEvent.setPayload("{\"payrollId\":\"" + payrollId + "\",\"error\":\"" + errorMessage + "\"}");
+        failureEvent.setPayload(toJson(Map.of("payrollId", payrollId, "error", errorMessage)));
         failureEvent.setStatus("PENDING");
         failureEvent.setRetryCount(0);
         failureEvent.setCreatedAt(LocalDateTime.now());
         outboxEventRepository.save(failureEvent);
+    }
+
+    private static String toJson(Map<String, Object> payload) {
+        try {
+            return MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize outbox payload", e);
+        }
     }
 }

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/service/PayrollEnterpriseService.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/service/PayrollEnterpriseService.java
@@ -2,6 +2,8 @@ package com.ems.payroll.service;
 
 import com.ems.payroll.model.*;
 import com.ems.payroll.repository.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,8 @@ import java.util.stream.Collectors;
 
 @Service
 public class PayrollEnterpriseService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final EnhancedPayrollRepository payrollRepo;
     private final CountryTaxConfigRepository taxConfigRepo;
@@ -139,7 +143,17 @@ public class PayrollEnterpriseService {
             outboxEvent.setAggregateType("payroll");
             outboxEvent.setAggregateId(String.valueOf(record.getId()));
             outboxEvent.setEventType("PAYROLL_PROCESSED");
-            outboxEvent.setPayload("{\"payrollId\":" + record.getId() + ",\"employeeId\":\"" + employeeId + "\",\"period\":\"" + period + "\",\"grossAmount\":" + grossSalary + ",\"netAmount\":" + netSalary + ",\"currency\":\"" + (currency != null ? currency : "USD") + "\",\"status\":\"PROCESSED\",\"timestamp\":\"" + LocalDateTime.now() + "\",\"tenantId\":\"" + tenantId + "\"}");
+            outboxEvent.setPayload(toJson(Map.of(
+                "payrollId", record.getId(),
+                "employeeId", employeeId,
+                "period", period,
+                "grossAmount", grossSalary,
+                "netAmount", netSalary,
+                "currency", currency != null ? currency : "USD",
+                "status", "PROCESSED",
+                "timestamp", LocalDateTime.now().toString(),
+                "tenantId", tenantId
+            )));
             outboxEvent.setStatus("PENDING");
             outboxEvent.setRetryCount(0);
             outboxEvent.setCreatedAt(LocalDateTime.now());
@@ -151,7 +165,13 @@ public class PayrollEnterpriseService {
             outboxEvent.setAggregateType("payroll");
             outboxEvent.setAggregateId("0");
             outboxEvent.setEventType("PAYROLL_FAILED");
-            outboxEvent.setPayload("{\"employeeId\":\"" + employeeId + "\",\"period\":\"" + period + "\",\"error\":\"" + e.getMessage() + "\",\"timestamp\":\"" + LocalDateTime.now() + "\",\"tenantId\":\"" + tenantId + "\"}");
+            outboxEvent.setPayload(toJson(Map.of(
+                "employeeId", employeeId,
+                "period", period,
+                "error", e.getMessage(),
+                "timestamp", LocalDateTime.now().toString(),
+                "tenantId", tenantId
+            )));
             outboxEvent.setStatus("PENDING");
             outboxEvent.setRetryCount(0);
             outboxEvent.setCreatedAt(LocalDateTime.now());
@@ -950,5 +970,13 @@ public class PayrollEnterpriseService {
 
     public List<Payslip> getEmployeePayslips(String tenantId, String employeeId) {
         return payslipRepo.findByTenantIdAndEmployeeId(tenantId, employeeId);
+    }
+
+    private static String toJson(Map<String, Object> payload) {
+        try {
+            return MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize outbox payload", e);
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes JSON injection vulnerability in Java outbox event payloads.

### Problem
All three payroll Java services built RabbitMQ outbox event payloads using raw string concatenation:
```java
"{\"employeeId\":\"" + employeeId + "\",\"error\":\"" + e.getMessage() + "\"}"
```
If any field contains double-quotes, backslashes, or control characters, the JSON breaks, corrupting downstream consumers and enabling injection-style attacks.

### Changes
- Replaced 6 string-concatenated JSON payloads with `ObjectMapper.writeValueAsString()` using `Map.of()` for structured serialization.
- Added a private static `ObjectMapper` and `toJson(Map)` helper to each service class.
- Jackson is already available via Spring Boot -- no new dependencies needed.

### Files changed
- **PayrollService.java**: Lines 66, 88 (PAYROLL_PROCESSED, PAYROLL_FAILED)
- **PayrollEnterpriseService.java**: Lines 146, 168 (PAYROLL_PROCESSED, PAYROLL_FAILED)
- **PayrollCompensationService.java**: Lines 58, 71 (PAYROLL_COMPENSATED, PAYROLL_FAILED)
