### PR TITLE
fix: add SecurityFilterChain to prevent default Spring Security auto-configuration (#33)

### DIFF
--- a/services/atlas-common/pom.xml
+++ b/services/atlas-common/pom.xml
@@ -30,5 +30,10 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/services/atlas-common/src/main/java/com/atlas/common/security/CommonSecurityAutoConfiguration.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/CommonSecurityAutoConfiguration.java
@@ -1,9 +1,28 @@
 package com.atlas.common.security;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 
 @AutoConfiguration
+@EnableWebSecurity
 @ComponentScan(basePackageClasses = { InternalAuthFilter.class, RoleAspect.class })
 public class CommonSecurityAutoConfiguration {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.csrf(csrf -> csrf.disable())
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/health").permitAll()
+				.anyRequest().permitAll()
+			)
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			);
+		return http.build();
+	}
 }


### PR DESCRIPTION
## Description

Adds a `SecurityFilterChain` bean to prevent Spring Boot's default security auto-configuration from generating a random password and potentially conflicting with the existing `InternalAuthFilter`.

### Problem
Three Java services (`payroll-java-service`, `leave-service`, `performance-service`) include `spring-boot-starter-security` in their POMs but have no `SecurityFilterChain` bean. This causes Spring Boot to:
1. Generate a random password logged to stdout on every startup
2. Apply default security that may block legitimate traffic
3. Create confusion about which auth mechanism is in effect

### Changes
- **CommonSecurityAutoConfiguration.java**: Added `@EnableWebSecurity` and a `SecurityFilterChain` bean that disables CSRF, permits all requests (the existing `InternalAuthFilter` handles actual authentication), and sets session management to STATELESS.
- **atlas-common/pom.xml**: Added `spring-boot-starter-security` as an optional dependency so the bean compiles in the shared library but is not transitively forced on consumers.

### Why permitAll?
The `InternalAuthFilter` is a servlet `@Component` filter that validates HMAC-signed internal JWT tokens. It already handles auth correctly. The `SecurityFilterChain` simply prevents Spring Security from interfering while deferring to the existing custom filter.
