### PR TITLE
fix: add pessimistic locking to outbox publisher to prevent duplicate messages (#35)

### DIFF
--- a/services/payroll-java-service/src/main/java/com/ems/payroll/repository/OutboxEventRepository.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/repository/OutboxEventRepository.java
@@ -1,7 +1,10 @@
 package com.ems.payroll.repository;
 
 import com.ems.payroll.model.OutboxEvent;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,5 +12,8 @@ import java.util.List;
 @Repository
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
     List<OutboxEvent> findByStatusOrderByCreatedAtAsc(String status);
-    List<OutboxEvent> findByStatusAndRetryCountLessThan(String status, int maxRetries);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM OutboxEvent e WHERE e.status = 'PENDING' AND e.retryCount < ?1")
+    List<OutboxEvent> findPendingEventsWithLock(int maxRetries);
 }

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/service/OutboxPublisherService.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/service/OutboxPublisherService.java
@@ -31,7 +31,7 @@ public class OutboxPublisherService {
     @Scheduled(fixedDelayString = "${outbox.poll.interval:5000}")
     @Transactional
     public void publishPendingEvents() {
-        List<OutboxEvent> pendingEvents = outboxEventRepository.findByStatusAndRetryCountLessThan("PENDING", maxRetries);
+        List<OutboxEvent> pendingEvents = outboxEventRepository.findPendingEventsWithLock(maxRetries);
         for (OutboxEvent event : pendingEvents) {
             try {
                 String routingKey = resolveRoutingKey(event.getEventType());


### PR DESCRIPTION
## Description

Fixes race condition in the outbox publisher that causes duplicate messages when multiple service instances are running.

### Problem
The `OutboxPublisherService.publishPendingEvents()` uses `@Scheduled` with `@Transactional` but the repository query had no locking. With horizontal scaling, two instances would both read the same PENDING events and publish both to RabbitMQ.

### Changes
- Added `@Lock(LockModeType.PESSIMISTIC_WRITE)` with a custom `@Query` to `OutboxEventRepository`
- Updated `OutboxPublisherService` to use the new `findPendingEventsWithLock()` method
- The `SELECT ... FOR UPDATE` ensures only one instance can read each pending event at a time

### Remaining concern
The `@Transactional` scope still covers the entire publish loop including RabbitMQ calls. A follow-up could split this into a two-phase approach (read-and-claim in one transaction, publish in another) but PESSIMISTIC_WRITE resolves the immediate duplicate message bug.

Closes #35
