### PR TITLE
fix: encrypt bank account and routing numbers at rest using JPA AttributeConverter (#36)

### DIFF
--- a/services/payroll-java-service/src/main/java/com/ems/payroll/model/BankTransaction.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/model/BankTransaction.java
@@ -12,7 +12,11 @@ public class BankTransaction {
     private String tenantId;
     private Long payrollId;
     private Double amount;
+
+    @Convert(converter = EncryptedStringConverter.class)
     private String accountNumber;
+
+    @Convert(converter = EncryptedStringConverter.class)
     private String routingNumber;
     private String bankName;
     private String accountType;

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/model/EncryptedStringConverter.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/model/EncryptedStringConverter.java
@@ -1,0 +1,65 @@
+package com.ems.payroll.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Converter
+public class EncryptedStringConverter implements AttributeConverter<String, String> {
+
+    private static final String ALGORITHM = "AES/ECB/PKCS5Padding";
+    private static final String ENV_KEY = "BANK_ENCRYPTION_KEY";
+    private static final String FALLBACK_KEY = "CHANGE-ME-32-CHAR-KEY-FOR-PROD!!";
+
+    private static SecretKeySpec keySpec;
+
+    private SecretKeySpec getKey() {
+        if (keySpec == null) {
+            String raw = System.getenv(ENV_KEY);
+            if (raw == null || raw.isEmpty()) {
+                raw = FALLBACK_KEY;
+            }
+            byte[] keyBytes;
+            if (raw.length() == 32) {
+                keyBytes = raw.getBytes(StandardCharsets.UTF_8);
+            } else {
+                MessageDigest sha = MessageDigest.getInstance("SHA-256");
+                keyBytes = Arrays.copyOf(sha.digest(raw.getBytes(StandardCharsets.UTF_8)), 32);
+            }
+            keySpec = new SecretKeySpec(keyBytes, "AES");
+        }
+        return keySpec;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, getKey());
+            byte[] encrypted = cipher.doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new RuntimeException("Encryption failed", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, getKey());
+            byte[] decrypted = cipher.doFinal(Base64.getDecoder().decode(dbData));
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Decryption failed", e);
+        }
+    }
+}

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/model/EncryptedStringConverter.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/model/EncryptedStringConverter.java
@@ -15,7 +15,6 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
 
     private static final String ALGORITHM = "AES/ECB/PKCS5Padding";
     private static final String ENV_KEY = "BANK_ENCRYPTION_KEY";
-    private static final String FALLBACK_KEY = "CHANGE-ME-32-CHAR-KEY-FOR-PROD!!";
 
     private static SecretKeySpec keySpec;
 
@@ -23,7 +22,7 @@ public class EncryptedStringConverter implements AttributeConverter<String, Stri
         if (keySpec == null) {
             String raw = System.getenv(ENV_KEY);
             if (raw == null || raw.isEmpty()) {
-                raw = FALLBACK_KEY;
+                throw new IllegalStateException("BANK_ENCRYPTION_KEY environment variable is not set");
             }
             byte[] keyBytes;
             if (raw.length() == 32) {


### PR DESCRIPTION
## Description

Encrypts bank account and routing numbers at rest using a JPA AttributeConverter to address the PCI DSS violation.

### Problem
`BankTransaction.accountNumber` and `BankTransaction.routingNumber` were stored as plaintext Strings in the database. PCI DSS Requirement 3.4 requires rendering PAN (Primary Account Number) unreadable at rest.

### Changes
- Created `EncryptedStringConverter` implementing `AttributeConverter<String, String>` using AES encryption
- Applied `@Convert(converter = EncryptedStringConverter.class)` to both `accountNumber` and `routingNumber` fields
- The encryption key is read from the `BANK_ENCRYPTION_KEY` environment variable
- Converter fails fast with `IllegalStateException` if the key is not configured

### Design notes
- Uses AES encryption (key derived via SHA-256 if not exactly 32 bytes)
- Encryption/decryption is transparent to the application code � getters and setters remain unchanged
- Existing data in `bank_transactions` table will become unreadable after deploy; a migration script should re-encrypt existing rows

Closes #36
