### PR TITLE
Add graceful shutdown to Go services with signal handling

### DIFF
--- a/services/attendance-service/main.go
+++ b/services/attendance-service/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/gofiber/adaptor/v2"
@@ -111,7 +114,7 @@ func initRabbitMQ() {
 	}
 }
 
-func consumeEmployeeDeletions() {
+func consumeEmployeeDeletions(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
@@ -185,18 +188,27 @@ func consumeEmployeeDeletions() {
 	}
 
 	log.Printf("Employee deletion consumer started on notifications_exchange")
-	for msg := range msgs {
-		var event struct {
-			Event    string `json:"event"`
-			Email    string `json:"email"`
-			TenantID string `json:"tenant_id"`
-		}
-		if err := json.Unmarshal(msg.Body, &event); err != nil {
-			log.Printf("Warning: Could not parse deletion event (%v)", err)
-			continue
-		}
-		if event.Event == "employee.deleted" {
-			handleEmployeeDeletion(event.TenantID, event.Email)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Employee deletion consumer shutting down")
+			return
+		case msg, ok := <-msgs:
+			if !ok {
+				return
+			}
+			var event struct {
+				Event    string `json:"event"`
+				Email    string `json:"email"`
+				TenantID string `json:"tenant_id"`
+			}
+			if err := json.Unmarshal(msg.Body, &event); err != nil {
+				log.Printf("Warning: Could not parse deletion event (%v)", err)
+				continue
+			}
+			if event.Event == "employee.deleted" {
+				handleEmployeeDeletion(event.TenantID, event.Email)
+			}
 		}
 	}
 }
@@ -268,9 +280,12 @@ func publishEvent(routingKey, tenantID string, record AttendanceRecord) {
 }
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	initDatabase()
 	initRabbitMQ()
-	go consumeEmployeeDeletions()
+	go consumeEmployeeDeletions(ctx)
 
 	app := fiber.New(fiber.Config{
 		AppName: "Atlas Attendance Service",
@@ -412,6 +427,22 @@ func main() {
 		port = "8005"
 	}
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down attendance service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+			log.Printf("Server shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("Atlas Attendance Service v2.0 listening on port %s", port)
-	app.Listen(":" + port)
+	if err := app.Listen(":" + port); err != nil {
+		log.Fatalf("Server error: %v", err)
+	}
 }

--- a/services/lms-service/main.go
+++ b/services/lms-service/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/atlas-workforce/lms-service/handlers"
@@ -139,7 +142,10 @@ func main() {
 	app.Use(middleware.AuthMiddleware())
 	app.Use(middleware.TenantMiddleware())
 
-	go startCertExpiryChecker()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startCertExpiryChecker(ctx)
 
 	app.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"status": "LMS Service is running"})
@@ -148,6 +154,21 @@ func main() {
 	setupRoutes(app)
 
 	log.Printf("LMS Service starting on port %s", serverPort)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down LMS service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+			log.Printf("Server shutdown error: %v", err)
+		}
+	}()
+
 	if err := app.Listen(":" + serverPort); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
@@ -160,15 +181,19 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-func startCertExpiryChecker() {
+func startCertExpiryChecker(ctx context.Context) {
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
 
-	// Run once at startup
 	checkExpiringCertifications()
 
-	for range ticker.C {
-		checkExpiringCertifications()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			checkExpiringCertifications()
+		}
 	}
 }
 

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -310,20 +313,23 @@ func handleConnections(w http.ResponseWriter, r *http.Request) {
 	client.readPump()
 }
 
-func handleMessages() {
+func handleMessages(ctx context.Context) {
 	for {
-		msg := <-broadcast
-		mutex.Lock()
-		for client := range clients {
-			if client.tenantID == msg.TenantID {
-				select {
-				case client.send <- msg.Payload:
-				default:
-					// skip slow client
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-broadcast:
+			mutex.Lock()
+			for client := range clients {
+				if client.tenantID == msg.TenantID {
+					select {
+					case client.send <- msg.Payload:
+					default:
+					}
 				}
 			}
+			mutex.Unlock()
 		}
-		mutex.Unlock()
 	}
 }
 
@@ -356,7 +362,7 @@ func markReadHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
-func setupRabbitMQConsumer() {
+func setupRabbitMQConsumer(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
@@ -439,8 +445,17 @@ func setupRabbitMQConsumer() {
 	}
 
 	log.Println("Waiting for messages from RabbitMQ...")
-	for d := range msgs {
-		processMessage(d.Body)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("RabbitMQ consumer shutting down")
+			return
+		case d, ok := <-msgs:
+			if !ok {
+				return
+			}
+			processMessage(d.Body)
+		}
 	}
 }
 
@@ -527,21 +542,20 @@ func main() {
 		port = "8004"
 	}
 
-	go handleMessages()
-	go setupRabbitMQConsumer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleMessages(ctx)
+	go setupRabbitMQConsumer(ctx)
 
 	mux := http.NewServeMux()
 
-	// Metrics
 	mux.Handle("/metrics", promhttp.Handler())
 
-	// Health
 	mux.HandleFunc("/health", healthHandler)
 
-	// WebSocket
 	mux.HandleFunc("/ws", handleConnections)
 
-	// REST API for notifications (requires internal auth)
 	mux.HandleFunc("/api/notifications", internalAuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
@@ -562,8 +576,28 @@ func main() {
 		}
 	}))
 
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: metricsMiddleware(mux),
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down notification service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("HTTP server shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("Notification Service listening on port %s", port)
-	if err := http.ListenAndServe(":"+port, metricsMiddleware(mux)); err != nil {
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+	<-ctx.Done()
 }


### PR DESCRIPTION
## Summary

Adds graceful shutdown with signal handling to all three Go services to prevent goroutine and connection leaks during Kubernetes pod termination.

## Changes

### attendance-service
- Added `signal.Notify` for SIGINT/SIGTERM
- Calls `app.ShutdownWithContext` with 10s timeout on signal
- `consumeEmployeeDeletions` now accepts `context.Context` for clean cancellation

### lms-service
- Added `signal.Notify` for SIGINT/SIGTERM  
- Calls `app.ShutdownWithContext` with 10s timeout on signal
- `startCertExpiryChecker` now accepts `context.Context` for clean cancellation

### notification-go-service
- Replaced bare `http.ListenAndServe` with `http.Server` + `Shutdown`
- Added `signal.Notify` for SIGINT/SIGTERM
- `handleMessages` and `setupRabbitMQConsumer` now accept `context.Context` for clean cancellation
- RabbitMQ consumer loop uses `select` on context Done instead of bare `range msgs`
