### PR TITLE
Fix cross-tenant notification data leak via query parameter

### DIFF
--- a/services/attendance-service/main.go
+++ b/services/attendance-service/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/gofiber/adaptor/v2"
@@ -111,7 +114,7 @@ func initRabbitMQ() {
 	}
 }
 
-func consumeEmployeeDeletions() {
+func consumeEmployeeDeletions(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
@@ -185,18 +188,27 @@ func consumeEmployeeDeletions() {
 	}
 
 	log.Printf("Employee deletion consumer started on notifications_exchange")
-	for msg := range msgs {
-		var event struct {
-			Event    string `json:"event"`
-			Email    string `json:"email"`
-			TenantID string `json:"tenant_id"`
-		}
-		if err := json.Unmarshal(msg.Body, &event); err != nil {
-			log.Printf("Warning: Could not parse deletion event (%v)", err)
-			continue
-		}
-		if event.Event == "employee.deleted" {
-			handleEmployeeDeletion(event.TenantID, event.Email)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Employee deletion consumer shutting down")
+			return
+		case msg, ok := <-msgs:
+			if !ok {
+				return
+			}
+			var event struct {
+				Event    string `json:"event"`
+				Email    string `json:"email"`
+				TenantID string `json:"tenant_id"`
+			}
+			if err := json.Unmarshal(msg.Body, &event); err != nil {
+				log.Printf("Warning: Could not parse deletion event (%v)", err)
+				continue
+			}
+			if event.Event == "employee.deleted" {
+				handleEmployeeDeletion(event.TenantID, event.Email)
+			}
 		}
 	}
 }
@@ -268,9 +280,12 @@ func publishEvent(routingKey, tenantID string, record AttendanceRecord) {
 }
 
 func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	initDatabase()
 	initRabbitMQ()
-	go consumeEmployeeDeletions()
+	go consumeEmployeeDeletions(ctx)
 
 	app := fiber.New(fiber.Config{
 		AppName: "Atlas Attendance Service",
@@ -412,6 +427,22 @@ func main() {
 		port = "8005"
 	}
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down attendance service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+			log.Printf("Server shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("Atlas Attendance Service v2.0 listening on port %s", port)
-	app.Listen(":" + port)
+	if err := app.Listen(":" + port); err != nil {
+		log.Fatalf("Server error: %v", err)
+	}
 }

--- a/services/attendance-service/main.go
+++ b/services/attendance-service/main.go
@@ -120,94 +120,102 @@ func consumeEmployeeDeletions(ctx context.Context) {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
 	}
 
-	conn, err := amqp.Dial(rabbitURL)
-	if err != nil {
-		log.Printf("Warning: Could not connect to RabbitMQ for deletion consumer (%v)", err)
-		return
-	}
-	defer conn.Close()
+	backoff := 1 * time.Second
+	maxBackoff := 30 * time.Second
 
-	ch, err := conn.Channel()
-	if err != nil {
-		log.Printf("Warning: Could not open channel for deletion consumer (%v)", err)
-		return
-	}
-	defer ch.Close()
-
-	err = ch.ExchangeDeclare(
-		"notifications_exchange",
-		"fanout",
-		true,
-		false,
-		false,
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Warning: Could not declare notifications_exchange (%v)", err)
-		return
-	}
-
-	q, err := ch.QueueDeclare(
-		"",
-		false,
-		false,
-		true,
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Warning: Could not declare queue (%v)", err)
-		return
-	}
-
-	err = ch.QueueBind(
-		q.Name,
-		"",
-		"notifications_exchange",
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Warning: Could not bind queue (%v)", err)
-		return
-	}
-
-	msgs, err := ch.Consume(
-		q.Name,
-		"",
-		true,
-		false,
-		false,
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Warning: Could not start consuming (%v)", err)
-		return
-	}
-
-	log.Printf("Employee deletion consumer started on notifications_exchange")
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("Employee deletion consumer shutting down")
 			return
-		case msg, ok := <-msgs:
-			if !ok {
+		default:
+		}
+
+		conn, err := amqp.Dial(rabbitURL)
+		if err != nil {
+			log.Printf("Warning: Could not connect to RabbitMQ for deletion consumer (%v), retrying in %v", err, backoff)
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		backoff = 1 * time.Second
+
+		ch, err := conn.Channel()
+		if err != nil {
+			log.Printf("Warning: Could not open channel (%v), reconnecting", err)
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		err = ch.ExchangeDeclare("notifications_exchange", "fanout", true, false, false, false, nil)
+		if err != nil {
+			log.Printf("Warning: Could not declare exchange (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		q, err := ch.QueueDeclare("", false, false, true, false, nil)
+		if err != nil {
+			log.Printf("Warning: Could not declare queue (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		err = ch.QueueBind(q.Name, "", "notifications_exchange", false, nil)
+		if err != nil {
+			log.Printf("Warning: Could not bind queue (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		msgs, err := ch.Consume(q.Name, "", true, false, false, false, nil)
+		if err != nil {
+			log.Printf("Warning: Could not start consuming (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		log.Printf("Employee deletion consumer started on notifications_exchange")
+
+	consumeLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				log.Println("Employee deletion consumer shutting down")
+				ch.Close()
+				conn.Close()
 				return
-			}
-			var event struct {
-				Event    string `json:"event"`
-				Email    string `json:"email"`
-				TenantID string `json:"tenant_id"`
-			}
-			if err := json.Unmarshal(msg.Body, &event); err != nil {
-				log.Printf("Warning: Could not parse deletion event (%v)", err)
-				continue
-			}
-			if event.Event == "employee.deleted" {
-				handleEmployeeDeletion(event.TenantID, event.Email)
+			case msg, ok := <-msgs:
+				if !ok {
+					log.Printf("RabbitMQ connection lost for deletion consumer, reconnecting")
+					ch.Close()
+					conn.Close()
+					break consumeLoop
+				}
+				var event struct {
+					Event    string `json:"event"`
+					Email    string `json:"email"`
+					TenantID string `json:"tenant_id"`
+				}
+				if err := json.Unmarshal(msg.Body, &event); err != nil {
+					log.Printf("Warning: Could not parse deletion event (%v)", err)
+					continue
+				}
+				if event.Event == "employee.deleted" {
+					handleEmployeeDeletion(event.TenantID, event.Email)
+				}
 			}
 		}
 	}

--- a/services/lms-service/main.go
+++ b/services/lms-service/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"regexp"
+	"syscall"
 	"time"
 
 	"github.com/atlas-workforce/lms-service/handlers"
@@ -139,7 +142,10 @@ func main() {
 	app.Use(middleware.AuthMiddleware())
 	app.Use(middleware.TenantMiddleware())
 
-	go startCertExpiryChecker()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go startCertExpiryChecker(ctx)
 
 	app.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"status": "LMS Service is running"})
@@ -148,6 +154,21 @@ func main() {
 	setupRoutes(app)
 
 	log.Printf("LMS Service starting on port %s", serverPort)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down LMS service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := app.ShutdownWithContext(shutdownCtx); err != nil {
+			log.Printf("Server shutdown error: %v", err)
+		}
+	}()
+
 	if err := app.Listen(":" + serverPort); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
@@ -160,15 +181,19 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-func startCertExpiryChecker() {
+func startCertExpiryChecker(ctx context.Context) {
 	ticker := time.NewTicker(24 * time.Hour)
 	defer ticker.Stop()
 
-	// Run once at startup
 	checkExpiringCertifications()
 
-	for range ticker.C {
-		checkExpiringCertifications()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			checkExpiringCertifications()
+		}
 	}
 }
 

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -368,93 +368,92 @@ func setupRabbitMQConsumer(ctx context.Context) {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
 	}
 
-	var conn *amqp.Connection
-	var err error
+	backoff := 1 * time.Second
+	maxBackoff := 30 * time.Second
 
-	for i := 0; i < 5; i++ {
-		conn, err = amqp.Dial(rabbitURL)
-		if err == nil {
-			break
-		}
-		log.Printf("Failed to connect to RabbitMQ, retrying... (%v)", err)
-		time.Sleep(5 * time.Second)
-	}
-
-	if err != nil {
-		log.Printf("Could not connect to RabbitMQ: %v", err)
-		return
-	}
-
-	ch, err := conn.Channel()
-	if err != nil {
-		log.Printf("Failed to open a channel: %v", err)
-		return
-	}
-
-	err = ch.ExchangeDeclare(
-		"notifications_exchange",
-		"fanout",
-		true,
-		false,
-		false,
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Failed to declare an exchange: %v", err)
-		return
-	}
-
-	q, err := ch.QueueDeclare(
-		"",    // empty name generates a unique temporary queue name
-		false, // non-durable
-		false, // delete when unused
-		true,  // exclusive
-		false, // no-wait
-		nil,   // arguments
-	)
-	if err != nil {
-		log.Printf("Failed to declare a queue: %v", err)
-		return
-	}
-
-	err = ch.QueueBind(
-		q.Name,
-		"",
-		"notifications_exchange",
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Failed to bind queue: %v", err)
-		return
-	}
-
-	msgs, err := ch.Consume(
-		q.Name,
-		"",
-		true,
-		false,
-		false,
-		false,
-		nil,
-	)
-	if err != nil {
-		log.Printf("Failed to register a consumer: %v", err)
-		return
-	}
-
-	log.Println("Waiting for messages from RabbitMQ...")
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("RabbitMQ consumer shutting down")
 			return
-		case d, ok := <-msgs:
-			if !ok {
-				return
+		default:
+		}
+
+		conn, err := amqp.Dial(rabbitURL)
+		if err != nil {
+			log.Printf("Failed to connect to RabbitMQ (%v), retrying in %v", err, backoff)
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
 			}
-			processMessage(d.Body)
+			continue
+		}
+
+		backoff = 1 * time.Second
+
+		ch, err := conn.Channel()
+		if err != nil {
+			log.Printf("Failed to open channel (%v), reconnecting", err)
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		err = ch.ExchangeDeclare("notifications_exchange", "fanout", true, false, false, false, nil)
+		if err != nil {
+			log.Printf("Failed to declare exchange (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		q, err := ch.QueueDeclare("", false, false, true, false, nil)
+		if err != nil {
+			log.Printf("Failed to declare queue (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		err = ch.QueueBind(q.Name, "", "notifications_exchange", false, nil)
+		if err != nil {
+			log.Printf("Failed to bind queue (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		msgs, err := ch.Consume(q.Name, "", true, false, false, false, nil)
+		if err != nil {
+			log.Printf("Failed to register consumer (%v), reconnecting", err)
+			ch.Close()
+			conn.Close()
+			time.Sleep(backoff)
+			continue
+		}
+
+		log.Println("Waiting for messages from RabbitMQ...")
+
+	consumeLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				log.Println("RabbitMQ consumer shutting down")
+				ch.Close()
+				conn.Close()
+				return
+			case d, ok := <-msgs:
+				if !ok {
+					log.Printf("RabbitMQ connection lost, reconnecting")
+					ch.Close()
+					conn.Close()
+					break consumeLoop
+				}
+				processMessage(d.Body)
+			}
 		}
 	}
 }

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -310,20 +313,23 @@ func handleConnections(w http.ResponseWriter, r *http.Request) {
 	client.readPump()
 }
 
-func handleMessages() {
+func handleMessages(ctx context.Context) {
 	for {
-		msg := <-broadcast
-		mutex.Lock()
-		for client := range clients {
-			if client.tenantID == msg.TenantID {
-				select {
-				case client.send <- msg.Payload:
-				default:
-					// skip slow client
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-broadcast:
+			mutex.Lock()
+			for client := range clients {
+				if client.tenantID == msg.TenantID {
+					select {
+					case client.send <- msg.Payload:
+					default:
+					}
 				}
 			}
+			mutex.Unlock()
 		}
-		mutex.Unlock()
 	}
 }
 
@@ -356,7 +362,7 @@ func markReadHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
-func setupRabbitMQConsumer() {
+func setupRabbitMQConsumer(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
 		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
@@ -439,8 +445,17 @@ func setupRabbitMQConsumer() {
 	}
 
 	log.Println("Waiting for messages from RabbitMQ...")
-	for d := range msgs {
-		processMessage(d.Body)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("RabbitMQ consumer shutting down")
+			return
+		case d, ok := <-msgs:
+			if !ok {
+				return
+			}
+			processMessage(d.Body)
+		}
 	}
 }
 
@@ -527,21 +542,20 @@ func main() {
 		port = "8004"
 	}
 
-	go handleMessages()
-	go setupRabbitMQConsumer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleMessages(ctx)
+	go setupRabbitMQConsumer(ctx)
 
 	mux := http.NewServeMux()
 
-	// Metrics
 	mux.Handle("/metrics", promhttp.Handler())
 
-	// Health
 	mux.HandleFunc("/health", healthHandler)
 
-	// WebSocket
 	mux.HandleFunc("/ws", handleConnections)
 
-	// REST API for notifications (requires internal auth)
 	mux.HandleFunc("/api/notifications", internalAuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
@@ -562,8 +576,28 @@ func main() {
 		}
 	}))
 
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: metricsMiddleware(mux),
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("Shutting down notification service...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("HTTP server shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("Notification Service listening on port %s", port)
-	if err := http.ListenAndServe(":"+port, metricsMiddleware(mux)); err != nil {
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+	<-ctx.Done()
 }

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -88,6 +88,7 @@ type Client struct {
 	conn     *websocket.Conn
 	send     chan []byte
 	tenantID string
+	clientIP string
 }
 
 type BroadcastMessage struct {
@@ -141,11 +142,16 @@ func (s *NotificationStore) MarkRead(ids []string) {
 	}
 }
 
+const maxClients = 1000
+const maxConnsPerIP = 10
+
 var (
-	store     = &NotificationStore{}
-	clients   = make(map[*Client]bool)
-	broadcast = make(chan BroadcastMessage)
-	mutex     = &sync.Mutex{}
+	store         = &NotificationStore{}
+	clients       = make(map[*Client]bool)
+	broadcast     = make(chan BroadcastMessage)
+	mutex         = &sync.Mutex{}
+	ipConnections = make(map[string]int)
+	ipMutex       = &sync.Mutex{}
 )
 
 type wsClaims struct {
@@ -257,6 +263,7 @@ func (c *Client) readPump() {
 		delete(clients, c)
 		close(c.send)
 		mutex.Unlock()
+		releaseConnection(c.clientIP)
 		c.conn.Close()
 	}()
 
@@ -279,6 +286,26 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "Notification Service is running"})
 }
 
+func canAcceptConnection(ip string) bool {
+	ipMutex.Lock()
+	defer ipMutex.Unlock()
+	count := ipConnections[ip]
+	if count >= maxConnsPerIP {
+		return false
+	}
+	ipConnections[ip] = count + 1
+	return true
+}
+
+func releaseConnection(ip string) {
+	ipMutex.Lock()
+	defer ipMutex.Unlock()
+	ipConnections[ip]--
+	if ipConnections[ip] <= 0 {
+		delete(ipConnections, ip)
+	}
+}
+
 func handleConnections(w http.ResponseWriter, r *http.Request) {
 	tokenStr := r.URL.Query().Get("token")
 	if tokenStr == "" {
@@ -297,13 +324,33 @@ func handleConnections(w http.ResponseWriter, r *http.Request) {
 		tenantID = "default"
 	}
 
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		log.Printf("WebSocket Upgrade Error: %v", err)
+	clientIP := r.RemoteAddr
+	if idx := strings.LastIndex(clientIP, ":"); idx != -1 {
+		clientIP = clientIP[:idx]
+	}
+
+	if !canAcceptConnection(clientIP) {
+		http.Error(w, `{"error":"Too many connections from this IP"}`, http.StatusTooManyRequests)
 		return
 	}
 
-	client := &Client{conn: ws, send: make(chan []byte, 256), tenantID: tenantID}
+	mutex.Lock()
+	if len(clients) >= maxClients {
+		mutex.Unlock()
+		releaseConnection(clientIP)
+		http.Error(w, `{"error":"Server at maximum connection capacity"}`, http.StatusServiceUnavailable)
+		return
+	}
+	mutex.Unlock()
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("WebSocket Upgrade Error: %v", err)
+		releaseConnection(clientIP)
+		return
+	}
+
+	client := &Client{conn: ws, send: make(chan []byte, 256), tenantID: tenantID, clientIP: clientIP}
 
 	mutex.Lock()
 	clients[client] = true

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -383,9 +383,10 @@ func handleMessages(ctx context.Context) {
 // REST API handlers
 
 func listNotificationsHandler(w http.ResponseWriter, r *http.Request) {
-	tenantID := r.URL.Query().Get("tenant_id")
+	tenantID := r.Header.Get("X-Tenant-Id")
 	if tenantID == "" {
-		tenantID = r.Header.Get("X-Tenant-Id")
+		http.Error(w, `{"error":"Missing tenant context"}`, http.StatusForbidden)
+		return
 	}
 	notifications := store.List(tenantID)
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Remove the tenant_id query parameter that took precedence over the X-Tenant-Id header, allowing any authenticated user to read any tenant's notifications. Now always uses the header value and returns 403 if missing.