### PR TITLE
Fix employee & analytics service RABBITMQ_PASSWORD KeyError (#125)

### DIFF
--- a/services/analytics-python-service/main.py
+++ b/services/analytics-python-service/main.py
@@ -132,10 +132,22 @@ def health_check():
     return {"status": "Analytics Service is running"}
 
 
+RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "")
 RABBITMQ_HOST = os.environ.get("RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = int(os.environ.get("RABBITMQ_PORT", "5672"))
-RABBITMQ_USER = os.environ["RABBITMQ_USER"]
-RABBITMQ_PASSWORD = os.environ["RABBITMQ_PASSWORD"]
+RABBITMQ_USER = os.environ.get("RABBITMQ_USER", "guest")
+RABBITMQ_PASSWORD = os.environ.get("RABBITMQ_PASSWORD", "guest")
+
+
+def _rabbitmq_params():
+    if RABBITMQ_URL:
+        return pika.URLParameters(RABBITMQ_URL)
+    return pika.ConnectionParameters(
+        host=RABBITMQ_HOST,
+        port=RABBITMQ_PORT,
+        credentials=pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD),
+    )
+
 
 EMPLOYEE_SERVICE_URL = os.environ.get("EMPLOYEE_SERVICE_URL", "http://employee-service:8001")
 
@@ -785,12 +797,7 @@ def payroll_processed_consumer():
 
     while True:
         try:
-            credentials = pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD)
-            params = pika.ConnectionParameters(
-                host=RABBITMQ_HOST,
-                port=RABBITMQ_PORT,
-                credentials=credentials,
-            )
+            params = _rabbitmq_params()
             connection = pika.BlockingConnection(params)
             channel = connection.channel()
             channel.exchange_declare(exchange="live_exchange", exchange_type="topic", durable=True)
@@ -823,12 +830,7 @@ def employee_deletion_consumer():
 
     while True:
         try:
-            credentials = pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD)
-            params = pika.ConnectionParameters(
-                host=RABBITMQ_HOST,
-                port=RABBITMQ_PORT,
-                credentials=credentials,
-            )
+            params = _rabbitmq_params()
             connection = pika.BlockingConnection(params)
             channel = connection.channel()
             channel.exchange_declare(exchange="notifications_exchange", exchange_type="fanout", durable=True)

--- a/services/analytics-python-service/test_rabbitmq_env.py
+++ b/services/analytics-python-service/test_rabbitmq_env.py
@@ -1,0 +1,28 @@
+"""Regression test for issue #125: ensure the service imports without RabbitMQ env vars set."""
+
+import os
+import subprocess
+import sys
+
+
+def test_analytics_service_imports_without_rabbitmq_env():
+    env = dict(os.environ)
+    for key in (
+        "RABBITMQ_URL",
+        "RABBITMQ_HOST",
+        "RABBITMQ_PORT",
+        "RABBITMQ_USER",
+        "RABBITMQ_PASSWORD",
+    ):
+        env.pop(key, None)
+    env["POSTGRES_USER"] = "test"
+    env["POSTGRES_PASSWORD"] = "test"
+    result = subprocess.run(
+        [sys.executable, "-c", "import main"],
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr

--- a/services/employee-python-service/main.py
+++ b/services/employee-python-service/main.py
@@ -64,10 +64,11 @@ DB_NAME = "atlas_db"
 
 INTERNAL_KEY = os.environ.get("INTERNAL_KEY", "")
 
+RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "")
 RABBITMQ_HOST = os.environ.get("RABBITMQ_HOST", "localhost")
 RABBITMQ_PORT = int(os.environ.get("RABBITMQ_PORT", "5672"))
 RABBITMQ_USER = os.environ.get("RABBITMQ_USER", "guest")
-RABBITMQ_PASSWORD = os.environ["RABBITMQ_PASSWORD"]
+RABBITMQ_PASSWORD = os.environ.get("RABBITMQ_PASSWORD", "guest")
 
 client = AsyncIOMotorClient(MONGO_URL)
 db = client[DB_NAME]
@@ -151,12 +152,15 @@ async def publish_delete_event(email: str, tenant_id: str):
 
 def _publish_delete_event_sync(email: str, tenant_id: str):
     try:
-        credentials = pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD)
-        params = pika.ConnectionParameters(
-            host=RABBITMQ_HOST,
-            port=RABBITMQ_PORT,
-            credentials=credentials,
-        )
+        if RABBITMQ_URL:
+            params = pika.URLParameters(RABBITMQ_URL)
+        else:
+            credentials = pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASSWORD)
+            params = pika.ConnectionParameters(
+                host=RABBITMQ_HOST,
+                port=RABBITMQ_PORT,
+                credentials=credentials,
+            )
         connection = pika.BlockingConnection(params)
         channel = connection.channel()
         channel.exchange_declare(exchange="notifications_exchange", exchange_type="fanout", durable=True)

--- a/services/employee-python-service/test_rabbitmq_env.py
+++ b/services/employee-python-service/test_rabbitmq_env.py
@@ -1,0 +1,32 @@
+"""Regression tests for issue #125: services must import without RABBITMQ_* env vars set."""
+
+import os
+import subprocess
+import sys
+
+
+def _import_main_without_rabbitmq_env():
+    env = dict(os.environ)
+    for key in (
+        "RABBITMQ_URL",
+        "RABBITMQ_HOST",
+        "RABBITMQ_PORT",
+        "RABBITMQ_USER",
+        "RABBITMQ_PASSWORD",
+    ):
+        env.pop(key, None)
+    env["MONGO_USER"] = "test"
+    env["MONGO_PASSWORD"] = "test"
+    return subprocess.run(
+        [sys.executable, "-c", "import main"],
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_employee_service_imports_without_rabbitmq_env():
+    result = _import_main_without_rabbitmq_env()
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Closes #125

## Problem
\docker compose up --build\ fails: employee-service and analytics-python-service crash at import time with \KeyError\ because RabbitMQ credentials are read via hard \os.environ[...]\ lookups while the compose blocks only provide \RABBITMQ_URL\.

## Changes
- **employee-python-service**: read \RABBITMQ_URL\ first (matches the service's compose env + \.env.example\), fall back to individual vars with safe \guest\ defaults; publisher uses \pika.URLParameters\ when a URL is set.
- **analytics-python-service**: same env handling; shared \_rabbitmq_params()\ helper used by both consumers.
- **Regression tests**: subprocess import guard proving both services import cleanly with all \RABBITMQ_*\ vars unset.

## Verification
- \python -m py_compile\ both services
- pytest: employee 7 passed, analytics 6 passed (CI-equivalent env)
- flake8 clean