### PR TITLE
Fix integration service 401 on every request - undefined INTERNAL_JWT_SECRET

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
       - INTERNAL_API_KEY=${AUDIT_INTERNAL_KEY:-atlas-internal-key-change-me}
+      - INTERNAL_JWT_SECRET=${INTERNAL_JWT_SECRET:-atlas-internal-jwt-secret-change-me}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
     networks:
       - atlas-network

--- a/services/integration-service/main.py
+++ b/services/integration-service/main.py
@@ -65,8 +65,12 @@ from schemas import (
 
 load_dotenv()
 
+configure_logging("integration-service", level=logging.INFO)
+logger = get_logger("integration-service")
+
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://atlas_user:atlas_password@postgres:5432/atlas_db")
 INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "svc-integration-key-change-in-production")
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000")
 MAX_PAGE_SIZE = 100
 
@@ -159,7 +163,8 @@ async def internal_auth_middleware(request: Request, call_next):
         claims = verify_internal_auth(request, INTERNAL_JWT_SECRET)
     except HTTPException as e:
         return JSONResponse(status_code=e.status_code, content={"error": e.detail})
-    except Exception:
+    except Exception as e:
+        logger.exception("Internal auth middleware failure (non-auth exception): %s", e)
         return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
 
     return await call_next(request)

--- a/services/integration-service/test_main.py
+++ b/services/integration-service/test_main.py
@@ -1,11 +1,45 @@
+import base64
+import hashlib
+import hmac
+import json
 import os
+import time
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
 os.environ.setdefault("INTERNAL_API_KEY", "test-key")
+os.environ.setdefault("INTERNAL_JWT_SECRET", "test-jwt-secret")
 
 from main import app  # noqa: E402
+
+
+def _mint_internal_token(secret: str = "test-jwt-secret", exp_offset: int = 3600) -> str:
+    """Mint an internal auth JWT matching atlas_observability.verify_internal_auth format."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=").decode()
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps({"sub": "integration-service", "exp": int(time.time()) + exp_offset}).encode()
+    ).rstrip(b"=").decode()
+    signing_input = f"{header}.{payload_b64}"
+    signature = base64.urlsafe_b64encode(
+        hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
+    ).rstrip(b"=").decode()
+    return f"{signing_input}.{signature}"
+
+
+def _mock_dashboard_stats():
+    return {
+        "total_webhooks": 0,
+        "active_webhooks": 0,
+        "total_subscriptions": 0,
+        "total_deliveries": 0,
+        "successful_deliveries": 0,
+        "failed_deliveries": 0,
+        "pending_deliveries": 0,
+        "outbox_pending": 0,
+        "outbox_failed": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -17,3 +51,52 @@ async def test_health_check():
         data = resp.json()
         assert data["status"] == "healthy"
         assert data["service"] == "integration-service"
+
+
+@pytest.mark.asyncio
+async def test_missing_internal_auth_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/integration/dashboard")
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "Missing internal authentication"
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": f"{_mint_internal_token()[:-10]}AAAAAAAAAA"},
+        )
+        assert resp.status_code == 401
+        assert "Invalid" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_valid_internal_token_passes_middleware(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": _mint_internal_token()},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == _mock_dashboard_stats()
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": _mint_internal_token(secret="wrong-secret")},
+        )
+        assert resp.status_code == 401
+        assert "Invalid" in resp.json()["error"]


### PR DESCRIPTION
Closes #127

**Root cause**: \INTERNAL_JWT_SECRET\ was used in \services/integration-service/main.py\ but never defined. The \NameError\ was swallowed by a blanket \except Exception\, so every request returned 401 \Invalid internal authentication\. Also, docker-compose never passed the env var to the container.

**Changes**:
- Define \INTERNAL_JWT_SECRET\ from environment (mirrors security-service pattern)
- Log the real exception instead of silently swallowing it
- Pass \INTERNAL_JWT_SECRET\ in docker-compose.yml
- Add regression tests: health, missing header, invalid signature, valid token, wrong secret

**Tests**: \python -m pytest test_main.py\ -> 5 passed