### PR TITLE
fix(security-service): define logger to fix 500 on PAM deny paths (#128)

### DIFF
--- a/services/security-service/main.py
+++ b/services/security-service/main.py
@@ -47,6 +47,8 @@ from schemas import (
 
 load_dotenv()
 
+logger = get_logger("security-service")
+
 DATABASE_URL = os.environ["DATABASE_URL"]
 INTERNAL_API_KEY = os.environ["INTERNAL_API_KEY"]
 MAX_PAGE_SIZE = int(os.getenv("MAX_PAGE_SIZE", "100"))


### PR DESCRIPTION
Fixes #128

## Summary

`logger` is referenced in the PAM deny paths of the security service (`services/security-service/main.py`) but was never assigned, so `logger.warning(...)` raised `NameError` before the 403 `HTTPException` could be constructed - clients received a generic `500` instead of the intended `403`.

## Change

- Adds `logger = get_logger(security-service)` after `load_dotenv()` in `services/security-service/main.py`, matching the convention used by sibling services (e.g. `ats-service/main.py:42`).
- `get_logger()` internally calls `configure_logging()` (`atlas_observability/logging_middleware.py`), so structured JSON logging with correlation IDs is enabled for the PAM deny events.

## Verification

- `python -m py_compile services/security-service/main.py` - passes.
- No other `logger` references exist in `main.py` without an assignment.
- `crud.py` uses its own stdlib logger and is unaffected.