### PR TITLE
fix(atlas-common): enforce employee ownership on employeeId-scoped endpoints (BOLA/IDOR) (#132)

### DIFF
--- a/services/atlas-common/src/main/java/com/atlas/common/security/RoleAspect.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/RoleAspect.java
@@ -8,12 +8,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.Map;
 
 @Aspect
 @Component
 public class RoleAspect {
+
+    private static final String EMPLOYEE_ROLE = "employee";
 
     @Around("@annotation(requiresRole)")
     public Object checkRole(ProceedingJoinPoint joinPoint, RequiresRole requiresRole) throws Throwable {
@@ -36,10 +39,62 @@ public class RoleAspect {
 
         for (String role : allowedRoles) {
             if (userRole.equalsIgnoreCase(role)) {
+                if (userRole.equalsIgnoreCase(EMPLOYEE_ROLE)
+                        && !verifySelfScoped(joinPoint, request)) {
+                    return ResponseEntity.status(403).body(Map.of(
+                            "error", "Forbidden: employees can only access their own records"));
+                }
                 return joinPoint.proceed();
             }
         }
 
         return ResponseEntity.status(403).body(Map.of("error", "Access denied: requires one of roles: " + String.join(", ", allowedRoles)));
+    }
+
+    /**
+     * Object-level authorization (BOLA/IDOR) guard for the employee role.
+     * When an employee role request carries an {@code employeeId} (path
+     * variable, query parameter or request body), the value must match the
+     * authenticated user id recorded by {@link InternalAuthFilter} as the
+     * {@code x-user-id} request attribute. Requests without an
+     * {@code employeeId} (aggregate/catalog endpoints) are left unchanged.
+     */
+    private boolean verifySelfScoped(ProceedingJoinPoint joinPoint, HttpServletRequest request) {
+        String userId = (String) request.getAttribute("x-user-id");
+        if (userId == null || userId.isBlank()) {
+            return false;
+        }
+
+        String requestedEmployeeId = resolveEmployeeId(joinPoint, request);
+        return requestedEmployeeId == null
+                || requestedEmployeeId.isBlank()
+                || userId.equals(requestedEmployeeId);
+    }
+
+    private String resolveEmployeeId(ProceedingJoinPoint joinPoint, HttpServletRequest request) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> uriVariables = (Map<String, String>) request.getAttribute(
+                HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (uriVariables != null) {
+            String pathParam = uriVariables.get("employeeId");
+            if (pathParam != null && !pathParam.isBlank()) {
+                return pathParam;
+            }
+        }
+
+        String queryParam = request.getParameter("employeeId");
+        if (queryParam != null && !queryParam.isBlank()) {
+            return queryParam;
+        }
+
+        for (Object arg : joinPoint.getArgs()) {
+            if (arg instanceof Map<?, ?>) {
+                Object bodyEmployeeId = ((Map<?, ?>) arg).get("employeeId");
+                if (bodyEmployeeId != null && !bodyEmployeeId.toString().isBlank()) {
+                    return bodyEmployeeId.toString();
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #132

## Problem

Object-level authorization (BOLA / IDOR) was missing across the Java services. `@RequiresRole` only verified the role string; it never compared the `employeeId` in the path/query/body against the authenticated `user_id` that `InternalAuthFilter` stores as the `x-user-id` request attribute. Any `employee`-role user could read any colleague's payslips, equity grants, leave history, goals and reviews by enumerating `employeeId`s.

## Fix (central, in the shared library)

`services/atlas-common/.../RoleAspect.java` now enforces ownership centrally for the `employee` role:

- When the authenticated role is `employee` and the request carries an `employeeId` (path variable, query parameter, or `Map` request body key), the value must equal the authenticated `x-user-id`; mismatch returns `403 Forbidden: employees can only access their own records`.
- Requests without an `employeeId` (aggregate/catalog endpoints) are left unchanged.
- Admin/HR/manager roles are unaffected - the ownership gate only applies to the `employee` role.

This single change closes the BOLA vectors for payroll (`/payslips/employee/{id}`, `/equity/employee/{id}`, benefit enrollment and expense submission bodies), leave (`/employee/{id}`, `/request`), and performance (`/goals`, `/reviews`, `/reviews/employee/{id}`) without touching each controller.

## Verification

- Static: change limited to `RoleAspect.java`; no controller/API contract changes.
- CI: `java-services-check` builds `atlas-common` (mvn install -DskipTests) then runs `mvn clean test` for payroll + leave - will confirm compile.

## Follow-up (out of scope)

Aggregate list endpoints that return all tenants/employees data to `employee` role (e.g. `GET /api/payroll/enterprise/payslips`, `GET /api/leave`) have no `employeeId` scope and remain untouched - recommend a follow-up to force self-scoping there.