### PR TITLE
Fix cross-tenant data access in Java services - bind tenant from verified JWT claims

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
       - INTERNAL_API_KEY=${AUDIT_INTERNAL_KEY:-atlas-internal-key-change-me}
+      - INTERNAL_JWT_SECRET=${INTERNAL_JWT_SECRET:-atlas-internal-jwt-secret-change-me}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
     networks:
       - atlas-network

--- a/services/atlas-common/src/main/java/com/atlas/common/security/CommonSecurityAutoConfiguration.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/CommonSecurityAutoConfiguration.java
@@ -7,6 +7,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @AutoConfiguration
 @EnableWebSecurity
@@ -24,5 +28,15 @@ public class CommonSecurityAutoConfiguration {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			);
 		return http.build();
+	}
+
+	@Bean
+	public WebMvcConfigurer tenantIdArgumentResolverConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+				resolvers.add(new TenantIdArgumentResolver());
+			}
+		};
 	}
 }

--- a/services/atlas-common/src/main/java/com/atlas/common/security/InternalAuthFilter.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/InternalAuthFilter.java
@@ -81,7 +81,14 @@ public class InternalAuthFilter implements Filter {
 				return;
 			}
 
-			request.setAttribute("x-tenant-id", claims.getOrDefault("tenant_id", "default"));
+			String tenantId = String.valueOf(claims.getOrDefault("tenant_id", "default"));
+			String headerTenantId = request.getHeader("X-Tenant-Id");
+			if (headerTenantId != null && !headerTenantId.isEmpty() && !tenantId.equals(headerTenantId)) {
+				sendError(response, 403, "Tenant mismatch: X-Tenant-Id does not match verified token claims");
+				return;
+			}
+
+			request.setAttribute("x-tenant-id", tenantId);
 			request.setAttribute("x-user-role", claims.getOrDefault("user_role", "employee"));
 			request.setAttribute("x-user-id", claims.getOrDefault("user_id", ""));
 

--- a/services/atlas-common/src/main/java/com/atlas/common/security/TenantId.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/TenantId.java
@@ -1,0 +1,11 @@
+package com.atlas.common.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TenantId {
+}

--- a/services/atlas-common/src/main/java/com/atlas/common/security/TenantIdArgumentResolver.java
+++ b/services/atlas-common/src/main/java/com/atlas/common/security/TenantIdArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.atlas.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class TenantIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+	public static final String TENANT_ID_ATTRIBUTE = "x-tenant-id";
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(TenantId.class)
+			&& String.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+		if (request != null) {
+			Object tenantId = request.getAttribute(TENANT_ID_ATTRIBUTE);
+			if (tenantId != null) {
+				return tenantId.toString();
+			}
+		}
+		return "default";
+	}
+}

--- a/services/integration-service/main.py
+++ b/services/integration-service/main.py
@@ -65,8 +65,12 @@ from schemas import (
 
 load_dotenv()
 
+configure_logging("integration-service", level=logging.INFO)
+logger = get_logger("integration-service")
+
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://atlas_user:atlas_password@postgres:5432/atlas_db")
 INTERNAL_API_KEY = os.getenv("INTERNAL_API_KEY", "svc-integration-key-change-in-production")
+INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET", "")
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:3000")
 MAX_PAGE_SIZE = 100
 
@@ -159,7 +163,8 @@ async def internal_auth_middleware(request: Request, call_next):
         claims = verify_internal_auth(request, INTERNAL_JWT_SECRET)
     except HTTPException as e:
         return JSONResponse(status_code=e.status_code, content={"error": e.detail})
-    except Exception:
+    except Exception as e:
+        logger.exception("Internal auth middleware failure (non-auth exception): %s", e)
         return JSONResponse(status_code=401, content={"error": "Invalid internal authentication"})
 
     return await call_next(request)

--- a/services/integration-service/test_main.py
+++ b/services/integration-service/test_main.py
@@ -1,11 +1,45 @@
+import base64
+import hashlib
+import hmac
+import json
 import os
+import time
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
 os.environ.setdefault("INTERNAL_API_KEY", "test-key")
+os.environ.setdefault("INTERNAL_JWT_SECRET", "test-jwt-secret")
 
 from main import app  # noqa: E402
+
+
+def _mint_internal_token(secret: str = "test-jwt-secret", exp_offset: int = 3600) -> str:
+    """Mint an internal auth JWT matching atlas_observability.verify_internal_auth format."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "HS256"}).encode()).rstrip(b"=").decode()
+    payload_b64 = base64.urlsafe_b64encode(
+        json.dumps({"sub": "integration-service", "exp": int(time.time()) + exp_offset}).encode()
+    ).rstrip(b"=").decode()
+    signing_input = f"{header}.{payload_b64}"
+    signature = base64.urlsafe_b64encode(
+        hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
+    ).rstrip(b"=").decode()
+    return f"{signing_input}.{signature}"
+
+
+def _mock_dashboard_stats():
+    return {
+        "total_webhooks": 0,
+        "active_webhooks": 0,
+        "total_subscriptions": 0,
+        "total_deliveries": 0,
+        "successful_deliveries": 0,
+        "failed_deliveries": 0,
+        "pending_deliveries": 0,
+        "outbox_pending": 0,
+        "outbox_failed": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -17,3 +51,52 @@ async def test_health_check():
         data = resp.json()
         assert data["status"] == "healthy"
         assert data["service"] == "integration-service"
+
+
+@pytest.mark.asyncio
+async def test_missing_internal_auth_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/integration/dashboard")
+        assert resp.status_code == 401
+        assert resp.json()["error"] == "Missing internal authentication"
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": f"{_mint_internal_token()[:-10]}AAAAAAAAAA"},
+        )
+        assert resp.status_code == 401
+        assert "Invalid" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_valid_internal_token_passes_middleware(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": _mint_internal_token()},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == _mock_dashboard_stats()
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_returns_401(monkeypatch):
+    monkeypatch.setattr("main.get_dashboard_stats", lambda db, tenant_id: _mock_dashboard_stats())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/integration/dashboard",
+            headers={"x-internal-auth": _mint_internal_token(secret="wrong-secret")},
+        )
+        assert resp.status_code == 401
+        assert "Invalid" in resp.json()["error"]

--- a/services/leave-service/src/main/java/com/atlas/leave/LeaveController.java
+++ b/services/leave-service/src/main/java/com/atlas/leave/LeaveController.java
@@ -1,6 +1,7 @@
 package com.atlas.leave;
 
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,14 +26,14 @@ public class LeaveController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping
     public ResponseEntity<List<LeaveRecord>> getAllLeaveRequests(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getAllLeaveRequests(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/employee/{employeeId}")
     public ResponseEntity<List<LeaveRecord>> getLeaveByEmployee(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getLeaveByEmployeeId(tenantId, employeeId));
     }
@@ -41,7 +42,7 @@ public class LeaveController {
     @PostMapping("/request")
     public ResponseEntity<?> requestLeave(
             @RequestBody Map<String, String> request,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             String employeeId = request.get("employeeId");
             LocalDate startDate = LocalDate.parse(request.get("startDate"));
@@ -63,7 +64,7 @@ public class LeaveController {
     public ResponseEntity<?> updateLeaveStatus(
             @PathVariable Long id,
             @RequestBody Map<String, String> request,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
 
         try {
             String status = request.get("status");

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/PayrollController.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/PayrollController.java
@@ -1,6 +1,7 @@
 package com.ems.payroll;
 
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +23,14 @@ public class PayrollController {
 
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping
-    public ResponseEntity<List<PayrollRecord>> getAllPayrolls(@RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+    public ResponseEntity<List<PayrollRecord>> getAllPayrolls(@TenantId String tenantId) {
         return ResponseEntity.ok(service.getAllPayrolls(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/employee/{employeeId}")
     public ResponseEntity<List<PayrollRecord>> getPayrollsByEmployee(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getPayrollsByEmployeeId(tenantId, employeeId));
     }
@@ -38,7 +39,7 @@ public class PayrollController {
     @PostMapping("/run")
     public ResponseEntity<?> runPayroll(
             @RequestBody Map<String, Object> request,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
 
         try {
             String employeeId = (String) request.get("employeeId");

--- a/services/payroll-java-service/src/main/java/com/ems/payroll/controller/PayrollEnterpriseController.java
+++ b/services/payroll-java-service/src/main/java/com/ems/payroll/controller/PayrollEnterpriseController.java
@@ -2,6 +2,7 @@ package com.ems.payroll.controller;
 
 import com.ems.payroll.model.*;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.ems.payroll.service.PayrollEnterpriseService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -28,7 +29,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/dashboard")
     public ResponseEntity<Map<String, Object>> getDashboard(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getDashboardSummary(tenantId));
     }
 
@@ -38,14 +39,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/payrolls")
     public ResponseEntity<List<EnhancedPayrollRecord>> getPayrolls(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getAllPayrolls(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/payrolls/employee/{employeeId}")
     public ResponseEntity<List<EnhancedPayrollRecord>> getPayrollsByEmployee(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getPayrollsByEmployee(tenantId, employeeId));
     }
@@ -53,7 +54,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/payrolls/period/{period}")
     public ResponseEntity<List<EnhancedPayrollRecord>> getPayrollsByPeriod(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String period) {
         return ResponseEntity.ok(service.getPayrollsByPeriod(tenantId, period));
     }
@@ -61,7 +62,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin"})
     @PostMapping("/payrolls/run")
     public ResponseEntity<?> runPayroll(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         try {
             EnhancedPayrollRecord record = service.runMultiCountryPayroll(
@@ -85,7 +86,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @GetMapping("/tax-configs")
     public ResponseEntity<List<CountryTaxConfig>> getTaxConfigs(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getTaxConfigs(tenantId));
     }
 
@@ -99,7 +100,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @GetMapping("/tax-brackets")
     public ResponseEntity<List<TaxBracket>> getTaxBrackets(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getTaxBrackets(tenantId));
     }
 
@@ -116,7 +117,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @PostMapping("/tax/simulate")
     public ResponseEntity<Map<String, Object>> simulateTax(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         String country = (String) req.getOrDefault("country", "US");
         Double grossSalary = Double.valueOf(req.getOrDefault("grossSalary", "0").toString());
@@ -126,7 +127,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @PostMapping("/tax/compare")
     public ResponseEntity<List<Map<String, Object>>> compareTax(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         @SuppressWarnings("unchecked")
         List<String> countries = (List<String>) req.getOrDefault("countries", List.of("US"));
@@ -140,7 +141,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @PostMapping("/forecasts/generate")
     public ResponseEntity<PayrollForecast> generateForecast(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, String> req) {
         String period = req.getOrDefault("period", "2026-Q2");
         return ResponseEntity.ok(service.generateForecast(tenantId, period));
@@ -149,7 +150,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @GetMapping("/forecasts")
     public ResponseEntity<List<PayrollForecast>> getForecasts(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getForecasts(tenantId));
     }
 
@@ -159,7 +160,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @GetMapping("/audit-logs")
     public ResponseEntity<List<PayrollAudit>> getAuditLogs(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getAuditLogs(tenantId));
     }
 
@@ -169,14 +170,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/payslips")
     public ResponseEntity<List<Payslip>> getPayslips(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getPayslips(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/payslips/employee/{employeeId}")
     public ResponseEntity<List<Payslip>> getEmployeePayslips(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getEmployeePayslips(tenantId, employeeId));
     }
@@ -187,7 +188,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin"})
     @PostMapping("/bank/transactions")
     public ResponseEntity<BankTransaction> createBankTransaction(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         BankTransaction tx = service.createBankTransaction(
                 tenantId,
@@ -203,7 +204,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/bank/transactions")
     public ResponseEntity<List<BankTransaction>> getBankTransactions(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getBankTransactions(tenantId));
     }
 
@@ -219,14 +220,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/expenses")
     public ResponseEntity<List<ExpenseReport>> getExpenses(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getExpenses(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/expenses/employee/{employeeId}")
     public ResponseEntity<List<ExpenseReport>> getExpensesByEmployee(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getExpensesByEmployee(tenantId, employeeId));
     }
@@ -234,7 +235,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @PostMapping("/expenses")
     public ResponseEntity<ExpenseReport> submitExpense(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         ExpenseReport expense = service.submitExpense(
                 tenantId,
@@ -268,14 +269,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/benefit-plans")
     public ResponseEntity<List<BenefitPlan>> getBenefitPlans(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getBenefitPlans(tenantId));
     }
 
     @RequiresRole({"admin", "hr"})
     @PostMapping("/benefit-plans")
     public ResponseEntity<BenefitPlan> createBenefitPlan(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         BenefitPlan plan = service.createBenefitPlan(
                 tenantId,
@@ -291,14 +292,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/benefit-enrollments")
     public ResponseEntity<List<BenefitEnrollment>> getBenefitEnrollments(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getBenefitEnrollments(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "employee"})
     @PostMapping("/benefit-enrollments")
     public ResponseEntity<BenefitEnrollment> enrollBenefit(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         return ResponseEntity.ok(service.enrollInBenefit(
                 tenantId,
@@ -312,14 +313,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/compensation-plans")
     public ResponseEntity<List<CompensationPlan>> getCompensationPlans(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getCompensationPlans(tenantId));
     }
 
     @RequiresRole({"admin", "hr"})
     @PostMapping("/compensation-plans")
     public ResponseEntity<CompensationPlan> createCompensationPlan(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         CompensationPlan plan = service.createCompensationPlan(
                 tenantId,
@@ -338,14 +339,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/bonuses")
     public ResponseEntity<List<Bonus>> getBonuses(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getBonuses(tenantId));
     }
 
     @RequiresRole({"admin", "hr"})
     @PostMapping("/bonuses")
     public ResponseEntity<Bonus> createBonus(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         Bonus bonus = service.createBonus(
                 tenantId,
@@ -370,14 +371,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/equity")
     public ResponseEntity<List<EquityGrant>> getEquity(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getEquityGrants(tenantId));
     }
 
     @RequiresRole({"admin"})
     @PostMapping("/equity")
     public ResponseEntity<EquityGrant> createEquityGrant(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         EquityGrant grant = service.createEquityGrant(
                 tenantId,
@@ -393,7 +394,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "employee"})
     @GetMapping("/equity/employee/{employeeId}")
     public ResponseEntity<List<EquityGrant>> getEmployeeEquity(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @PathVariable String employeeId) {
         return ResponseEntity.ok(service.getEmployeeEquity(tenantId, employeeId));
     }
@@ -404,14 +405,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/benchmarks")
     public ResponseEntity<List<SalaryBenchmark>> getBenchmarks(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getBenchmarks(tenantId));
     }
 
     @RequiresRole({"admin", "hr"})
     @PostMapping("/benchmarks")
     public ResponseEntity<SalaryBenchmark> addBenchmark(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         SalaryBenchmark benchmark = service.addBenchmark(
                 tenantId,
@@ -431,7 +432,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @PostMapping("/benchmarks/compare")
     public ResponseEntity<Map<String, Object>> compareBenchmark(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, Object> req) {
         return ResponseEntity.ok(service.compareToBenchmark(
                 tenantId,
@@ -447,14 +448,14 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/compliance-reports")
     public ResponseEntity<List<PayrollComplianceReport>> getComplianceReports(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getComplianceReports(tenantId));
     }
 
     @RequiresRole({"admin"})
     @PostMapping("/compliance-reports/generate")
     public ResponseEntity<PayrollComplianceReport> generateComplianceReport(
-            @RequestHeader("X-Tenant-Id") String tenantId,
+            @TenantId String tenantId,
             @RequestBody Map<String, String> req) {
         return ResponseEntity.ok(service.generateComplianceReport(
                 tenantId,
@@ -469,7 +470,7 @@ public class PayrollEnterpriseController {
     @RequiresRole({"admin", "hr"})
     @GetMapping("/anomalies")
     public ResponseEntity<List<PayrollAnomaly>> getAnomalies(
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getAnomalies(tenantId));
     }
 
@@ -477,7 +478,7 @@ public class PayrollEnterpriseController {
     @PostMapping("/anomalies/{id}/resolve")
     public ResponseEntity<PayrollAnomaly> resolveAnomaly(
             @PathVariable Long id,
-            @RequestHeader("X-Tenant-Id") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.resolveAnomaly(id, tenantId));
     }
 }

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/AnalyticsController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/AnalyticsController.java
@@ -1,6 +1,7 @@
 package com.atlas.performance.controller;
 
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,28 +22,28 @@ public class AnalyticsController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/overview")
     public ResponseEntity<Map<String, Object>> getOverview(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getAnalyticsOverview(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/department-ratings")
     public ResponseEntity<Map<String, Object>> getDepartmentRatings(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getDepartmentRatings(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/goal-completion")
     public ResponseEntity<Map<String, Object>> getGoalCompletion(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getGoalCompletionRates(tenantId));
     }
 
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/succession-readiness")
     public ResponseEntity<Map<String, Object>> getSuccessionReadiness(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getSuccessionReadiness(tenantId));
     }
 }

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/FeedbackController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/FeedbackController.java
@@ -2,6 +2,7 @@ package com.atlas.performance.controller;
 
 import com.atlas.performance.model.Feedback360;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class FeedbackController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping
     public ResponseEntity<List<Feedback360>> listFeedback(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @RequestParam(required = false) String employeeId,
             @RequestParam(required = false) String reviewerId) {
         return ResponseEntity.ok(service.getFeedbackList(tenantId, employeeId, reviewerId));
@@ -33,7 +34,7 @@ public class FeedbackController {
     @PostMapping
     public ResponseEntity<?> submitFeedback(
             @RequestBody Feedback360 feedback,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.submitFeedback(tenantId, feedback));
         } catch (IllegalArgumentException e) {
@@ -45,7 +46,7 @@ public class FeedbackController {
     @GetMapping("/{id}")
     public ResponseEntity<?> getFeedback(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.getFeedback(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -57,7 +58,7 @@ public class FeedbackController {
     @GetMapping("/employee/{employeeId}/summary")
     public ResponseEntity<Map<String, Object>> getFeedbackSummary(
             @PathVariable String employeeId,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getFeedbackSummary(tenantId, employeeId));
     }
 }

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/GoalController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/GoalController.java
@@ -2,6 +2,7 @@ package com.atlas.performance.controller;
 
 import com.atlas.performance.model.Goal;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class GoalController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping
     public ResponseEntity<List<Goal>> listGoals(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @RequestParam(required = false) String employeeId,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String category) {
@@ -35,7 +36,7 @@ public class GoalController {
     @PostMapping
     public ResponseEntity<?> createGoal(
             @RequestBody Goal goal,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.createGoal(tenantId, goal));
         } catch (IllegalArgumentException e) {
@@ -47,7 +48,7 @@ public class GoalController {
     @GetMapping("/{id}")
     public ResponseEntity<?> getGoal(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.getGoal(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -60,7 +61,7 @@ public class GoalController {
     public ResponseEntity<?> updateGoal(
             @PathVariable String id,
             @RequestBody Goal goal,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.updateGoal(tenantId, id, goal));
         } catch (IllegalArgumentException e) {
@@ -72,7 +73,7 @@ public class GoalController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteGoal(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             service.deleteGoal(tenantId, id);
             return ResponseEntity.ok(Map.of("message", "Goal deleted successfully"));
@@ -86,7 +87,7 @@ public class GoalController {
     public ResponseEntity<?> updateProgress(
             @PathVariable String id,
             @RequestBody Map<String, Object> request,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             BigDecimal progressPct = request.containsKey("progressPct")
                     ? new BigDecimal(request.get("progressPct").toString()) : null;
@@ -102,7 +103,7 @@ public class GoalController {
     public ResponseEntity<?> updateStatus(
             @PathVariable String id,
             @RequestBody Map<String, String> request,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.updateGoalStatus(tenantId, id, request.get("status")));
         } catch (IllegalArgumentException e) {

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/PerformanceReviewController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/PerformanceReviewController.java
@@ -2,6 +2,7 @@ package com.atlas.performance.controller;
 
 import com.atlas.performance.model.PerformanceReview;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class PerformanceReviewController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping
     public ResponseEntity<List<PerformanceReview>> listReviews(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @RequestParam(required = false) String employeeId,
             @RequestParam(required = false) String reviewerId,
             @RequestParam(required = false) String status,
@@ -35,7 +36,7 @@ public class PerformanceReviewController {
     @PostMapping
     public ResponseEntity<?> createReview(
             @RequestBody PerformanceReview review,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.createReview(tenantId, review));
         } catch (IllegalArgumentException e) {
@@ -47,7 +48,7 @@ public class PerformanceReviewController {
     @GetMapping("/{id}")
     public ResponseEntity<?> getReview(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.getReview(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -60,7 +61,7 @@ public class PerformanceReviewController {
     public ResponseEntity<?> updateReview(
             @PathVariable String id,
             @RequestBody PerformanceReview review,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.updateReview(tenantId, id, review));
         } catch (IllegalArgumentException e) {
@@ -72,7 +73,7 @@ public class PerformanceReviewController {
     @PutMapping("/{id}/submit")
     public ResponseEntity<?> submitReview(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.submitReview(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -84,7 +85,7 @@ public class PerformanceReviewController {
     @PutMapping("/{id}/acknowledge")
     public ResponseEntity<?> acknowledgeReview(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.acknowledgeReview(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -96,7 +97,7 @@ public class PerformanceReviewController {
     @GetMapping("/cycle/{cycle}")
     public ResponseEntity<List<PerformanceReview>> getReviewsByCycle(
             @PathVariable String cycle,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getReviewsByCycle(tenantId, cycle));
     }
 
@@ -104,7 +105,7 @@ public class PerformanceReviewController {
     @GetMapping("/employee/{employeeId}")
     public ResponseEntity<List<PerformanceReview>> getReviewHistory(
             @PathVariable String employeeId,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getReviewHistory(tenantId, employeeId));
     }
 }

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/RecognitionController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/RecognitionController.java
@@ -2,6 +2,7 @@ package com.atlas.performance.controller;
 
 import com.atlas.performance.model.Recognition;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class RecognitionController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping
     public ResponseEntity<List<Recognition>> listRecognitions(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @RequestParam(required = false) String employeeId,
             @RequestParam(required = false) String category) {
         return ResponseEntity.ok(service.getRecognitions(tenantId, employeeId, category));
@@ -33,7 +34,7 @@ public class RecognitionController {
     @PostMapping
     public ResponseEntity<?> giveRecognition(
             @RequestBody Recognition recognition,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.giveRecognition(tenantId, recognition));
         } catch (IllegalArgumentException e) {
@@ -44,7 +45,7 @@ public class RecognitionController {
     @RequiresRole({"admin", "hr", "manager", "employee"})
     @GetMapping("/wall")
     public ResponseEntity<List<Recognition>> getRecognitionWall(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getRecognitionWall(tenantId));
     }
 }

--- a/services/performance-service/src/main/java/com/atlas/performance/controller/SuccessionController.java
+++ b/services/performance-service/src/main/java/com/atlas/performance/controller/SuccessionController.java
@@ -3,6 +3,7 @@ package com.atlas.performance.controller;
 import com.atlas.performance.model.SuccessionCandidate;
 import com.atlas.performance.model.SuccessionPlan;
 import com.atlas.common.security.RequiresRole;
+import com.atlas.common.security.TenantId;
 import com.atlas.performance.service.PerformanceService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,7 @@ public class SuccessionController {
     @RequiresRole({"admin", "hr", "manager"})
     @GetMapping("/plans")
     public ResponseEntity<List<SuccessionPlan>> listPlans(
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId,
+            @TenantId String tenantId,
             @RequestParam(required = false) String department,
             @RequestParam(required = false) String status) {
         return ResponseEntity.ok(service.getSuccessionPlans(tenantId, department, status));
@@ -34,7 +35,7 @@ public class SuccessionController {
     @PostMapping("/plans")
     public ResponseEntity<?> createPlan(
             @RequestBody SuccessionPlan plan,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.createSuccessionPlan(tenantId, plan));
         } catch (IllegalArgumentException e) {
@@ -46,7 +47,7 @@ public class SuccessionController {
     @GetMapping("/plans/{id}")
     public ResponseEntity<?> getPlan(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.getSuccessionPlanWithCandidates(tenantId, id));
         } catch (IllegalArgumentException e) {
@@ -59,7 +60,7 @@ public class SuccessionController {
     public ResponseEntity<?> updatePlan(
             @PathVariable String id,
             @RequestBody SuccessionPlan plan,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.updateSuccessionPlan(tenantId, id, plan));
         } catch (IllegalArgumentException e) {
@@ -71,7 +72,7 @@ public class SuccessionController {
     @DeleteMapping("/plans/{id}")
     public ResponseEntity<?> deletePlan(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             service.deleteSuccessionPlan(tenantId, id);
             return ResponseEntity.ok(Map.of("message", "Succession plan deleted successfully"));
@@ -84,7 +85,7 @@ public class SuccessionController {
     @PostMapping("/candidates")
     public ResponseEntity<?> addCandidate(
             @RequestBody SuccessionCandidate candidate,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.addCandidate(tenantId, candidate));
         } catch (IllegalArgumentException e) {
@@ -97,7 +98,7 @@ public class SuccessionController {
     public ResponseEntity<?> updateCandidate(
             @PathVariable String id,
             @RequestBody SuccessionCandidate candidate,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             return ResponseEntity.ok(service.updateCandidate(tenantId, id, candidate));
         } catch (IllegalArgumentException e) {
@@ -109,7 +110,7 @@ public class SuccessionController {
     @DeleteMapping("/candidates/{id}")
     public ResponseEntity<?> removeCandidate(
             @PathVariable String id,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         try {
             service.removeCandidate(tenantId, id);
             return ResponseEntity.ok(Map.of("message", "Candidate removed successfully"));
@@ -122,7 +123,7 @@ public class SuccessionController {
     @GetMapping("/readiness/{employeeId}")
     public ResponseEntity<List<SuccessionCandidate>> getEmployeeReadiness(
             @PathVariable String employeeId,
-            @RequestHeader(value = "X-Tenant-Id", defaultValue = "default") String tenantId) {
+            @TenantId String tenantId) {
         return ResponseEntity.ok(service.getEmployeeReadiness(tenantId, employeeId));
     }
 }


### PR DESCRIPTION
Closes #131

**Root cause**: The shared `InternalAuthFilter` extracted the verified `tenant_id` from the signed `x-internal-auth` JWT into a request attribute, but all controllers bound `X-Tenant-Id` straight from the client header. Any caller could send `X-Tenant-Id: <other-tenant>` and read/write that tenant's leave, payroll and performance data.

**Changes** (defense in depth):
1. New `@TenantId` annotation + `TenantIdArgumentResolver` in atlas-common, registered via `WebMvcConfigurer` in `CommonSecurityAutoConfiguration`. Controllers now receive the tenant from `request.getAttribute("x-tenant-id")` (the verified claim) — the client header is never consulted.
2. `InternalAuthFilter`: if a caller still sends `X-Tenant-Id` that mismatches the verified claim, the request is rejected with 403. Even un-migrated endpoints can no longer be coerced.
3. All 82 controller parameter bindings replaced across the three Java services:
   - leave-service: `LeaveController` (4)
   - payroll-java-service: `PayrollController` (3), `PayrollEnterpriseController` (37)
   - performance-service: `AnalyticsController` (4), `FeedbackController` (4), `GoalController` (7), `PerformanceReviewController` (8), `RecognitionController` (3), `SuccessionController` (9)

**Behavior preserved**: if the claim has no `tenant_id`, the previous `default` semantics still apply via the filter attribute/fallback.