### PR TITLE
fix(security): fail fast on known default secrets outside development (issue #130)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       - "8080:8080"
     environment:
       - JWT_SECRET=${JWT_SECRET:-change-me-to-a-long-random-string}
+      - NODE_ENV=${NODE_ENV:-development}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
       - AUTH_SERVICE_URL=http://auth-service:8010
       - EMPLOYEE_SERVICE_URL=http://employee-service:8001

--- a/services/api-gateway-node/index.js
+++ b/services/api-gateway-node/index.js
@@ -126,6 +126,11 @@ if (!JWT_SECRET) {
   process.exit(1);
 }
 
+if (NODE_ENV !== 'development' && (INTERNAL_JWT_SECRET === 'atlas-internal-jwt-secret-change-me' || JWT_SECRET === 'change-me-to-a-long-random-string')) {
+  console.error('FATAL: refusing to start outside development with known default secrets (INTERNAL_JWT_SECRET / JWT_SECRET); set strong values via .env');
+  process.exit(1);
+}
+
 const jwtSecret = JWT_SECRET;
 
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')

--- a/services/auth-service/index.js
+++ b/services/auth-service/index.js
@@ -119,6 +119,11 @@ if (!SCIM_API_KEY) {
   process.exit(1);
 }
 
+if (NODE_ENV !== 'development' && (JWT_SECRET === 'change-me-to-a-long-random-string' || ADMIN_DEFAULT_PASSWORD === 'ChangeMe123!')) {
+  console.error('FATAL: refusing to start outside development with known default secrets (JWT_SECRET / ADMIN_DEFAULT_PASSWORD); set strong values via .env');
+  process.exit(1);
+}
+
 const jwtSecret = JWT_SECRET;
 
 if (!process.env.POSTGRES_URL) {


### PR DESCRIPTION
﻿## Summary

Fixes #130 - the compose stack ships known public default secrets (`INTERNAL_JWT_SECRET=atlas-internal-jwt-secret-change-me`, `JWT_SECRET=change-me-to-a-long-random-string`, `ADMIN_DEFAULT_PASSWORD=ChangeMe123!`) that make `x-internal-auth` forging and admin takeovers trivial for anyone who deploys without overriding them.

## Fix

Implements the issue's suggested fix: fail-fast on known default values outside `NODE_ENV=development` (auth-service already gates some behavior on NODE_ENV).

- **services/auth-service/index.js** - new bootstrap guard: if `NODE_ENV != development` and `JWT_SECRET` or `ADMIN_DEFAULT_PASSWORD` equals its public default, log FATAL and `process.exit(1)` before DB init or admin auto-provisioning runs.
- **services/api-gateway-node/index.js** - new bootstrap guard: if `NODE_ENV != development` and `INTERNAL_JWT_SECRET` or `JWT_SECRET` equals its public default, log FATAL and `process.exit(1)`.
- **docker-compose.yml** - api-gateway now receives `NODE_ENV=${NODE_ENV:-development}` (previously unset, so its guard could never engage in production deploys). Local `docker compose up --build` keeps working unchanged since development still permits the defaults.

## Behavior matrix (tested)

- NODE_ENV=production + default secrets -> exit 1, FATAL message
- NODE_ENV=production + overridden secrets -> starts
- NODE_ENV=development + defaults -> starts (local dev unchanged)

## Verification

- `node --check` on both services - OK
- Compose YAML parses - OK
- Guard condition matrix exercised in isolation - 3/3 as expected

Not merged to main - review first.
