### PR TITLE
RabbitMQ credentials mismatch out of the box (#129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,8 @@ MONGO_PASSWORD=
 MONGO_DB=atlas_db
 MONGO_URL=mongodb://admin:admin_password@mongodb:27017/atlas_db?authSource=admin
 INTERNAL_KEY=
-RABBITMQ_USER=guest
-RABBITMQ_PASSWORD=
+RABBITMQ_USER=atlas_rabbit
+RABBITMQ_PASS=changeme_rabbit_pass
 
 # ── Analytics Service ───────────────────────────────────────────────────────
 POSTGRES_USER=atlas_user
@@ -48,8 +48,8 @@ POSTGRES_PASSWORD=
 POSTGRES_HOST=postgres
 POSTGRES_DB=atlas_db
 INTERNAL_JWT_SECRET=
-RABBITMQ_USER=guest
-RABBITMQ_PASSWORD=
+RABBITMQ_USER=atlas_rabbit
+RABBITMQ_PASS=changeme_rabbit_pass
 
 # ── Security Service ────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://atlas_user:atlas_password@postgres:5432/atlas_security

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-atlas_user}:${POSTGRES_PASSWORD:-atlas_password}@postgres:5432/${POSTGRES_DB:-atlas_db}
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
-      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-atlas_rabbit}:${RABBITMQ_PASS:-changeme_rabbit_pass}@rabbitmq:5672/
       - INTERNAL_API_KEY=${AUDIT_INTERNAL_KEY:-atlas-internal-key-change-me}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
     networks:
@@ -211,7 +211,7 @@ services:
       - "8001:8001"
     environment:
       - MONGO_URL=mongodb://${MONGO_USER:-admin}:${MONGO_PASSWORD:-changeme_mongo_pass}@mongodb:27017/${MONGO_DB:-atlas_db}?authSource=admin
-      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-atlas_rabbit}:${RABBITMQ_PASS:-changeme_rabbit_pass}@rabbitmq:5672/
     networks:
       - atlas-network
     depends_on:
@@ -229,6 +229,8 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD:-atlas_password}
       - SPRING_RABBITMQ_HOST=rabbitmq
       - SPRING_RABBITMQ_PORT=5672
+      - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USER:-atlas_rabbit}
+      - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASS:-changeme_rabbit_pass}
     networks:
       - atlas-network
     depends_on:
@@ -244,6 +246,7 @@ services:
       - "8003:8003"
     environment:
       - POSTGRES_URL=postgresql://${POSTGRES_USER:-atlas_user}:${POSTGRES_PASSWORD:-atlas_password}@postgres:5432/${POSTGRES_DB:-atlas_db}
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-atlas_rabbit}:${RABBITMQ_PASS:-changeme_rabbit_pass}@rabbitmq:5672/
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
     networks:
       - atlas-network
@@ -257,7 +260,7 @@ services:
     ports:
       - "8004:8004"
     environment:
-      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672/
+      - RABBITMQ_URL=amqp://${RABBITMQ_USER:-atlas_rabbit}:${RABBITMQ_PASS:-changeme_rabbit_pass}@rabbitmq:5672/
       - INTERNAL_JWT_SECRET=${INTERNAL_JWT_SECRET:-atlas-internal-jwt-secret-change-me}
     networks:
       - atlas-network

--- a/services/attendance-service/main.go
+++ b/services/attendance-service/main.go
@@ -85,7 +85,7 @@ func initDatabase() {
 func initRabbitMQ() {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
-		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
+		rabbitURL = "amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/"
 	}
 
 	conn, err := amqp.Dial(rabbitURL)
@@ -117,7 +117,7 @@ func initRabbitMQ() {
 func consumeEmployeeDeletions(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
-		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
+		rabbitURL = "amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/"
 	}
 
 	backoff := 1 * time.Second

--- a/services/employee-python-service/.env.example
+++ b/services/employee-python-service/.env.example
@@ -1,4 +1,4 @@
 # Employee Service
 PORT=8001
 MONGO_URL=mongodb://admin:admin_password@mongodb:27017/atlas_db?authSource=admin
-RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+RABBITMQ_URL=amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/

--- a/services/integration-service/.env.example
+++ b/services/integration-service/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://atlas_user:atlas_password@postgres:5432/atlas_db
 KAFKA_BOOTSTRAP_SERVERS=kafka:9092
-RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+RABBITMQ_URL=amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/
 INTERNAL_API_KEY=svc-integration-key-change-in-production
 CORS_ORIGINS=http://localhost:3000

--- a/services/integration-service/event_router.py
+++ b/services/integration-service/event_router.py
@@ -25,7 +25,7 @@ from webhook_engine import deliver_webhook, send_audit_event
 
 logger = logging.getLogger("event-router")
 
-RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672/")
+RABBITMQ_URL = os.environ.get("RABBITMQ_URL", "amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/")
 RABBITMQ_EXCHANGE = "notifications_exchange"
 
 _rabbit_connection = None

--- a/services/live-service/main.py
+++ b/services/live-service/main.py
@@ -26,7 +26,7 @@ from atlas_observability import (
 load_dotenv()
 
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
-RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq:5672/")
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/")
 INTERNAL_JWT_SECRET = os.environ.get("INTERNAL_JWT_SECRET")
 
 # ── Eviction Configuration ──────────────────────────────────────────────────

--- a/services/notification-go-service/.env.example
+++ b/services/notification-go-service/.env.example
@@ -1,3 +1,3 @@
 # Notification Service
 PORT=8004
-RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+RABBITMQ_URL=amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/

--- a/services/notification-go-service/main.go
+++ b/services/notification-go-service/main.go
@@ -413,7 +413,7 @@ func markReadHandler(w http.ResponseWriter, r *http.Request) {
 func setupRabbitMQConsumer(ctx context.Context) {
 	rabbitURL := os.Getenv("RABBITMQ_URL")
 	if rabbitURL == "" {
-		rabbitURL = "amqp://guest:guest@rabbitmq:5672/"
+		rabbitURL = "amqp://atlas_rabbit:changeme_rabbit_pass@rabbitmq:5672/"
 	}
 
 	backoff := 1 * time.Second

--- a/services/payroll-java-service/src/main/resources/application.properties
+++ b/services/payroll-java-service/src/main/resources/application.properties
@@ -7,6 +7,8 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 spring.rabbitmq.host=${SPRING_RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${SPRING_RABBITMQ_PORT:5672}
+spring.rabbitmq.username=${SPRING_RABBITMQ_USERNAME:guest}
+spring.rabbitmq.password=${SPRING_RABBITMQ_PASSWORD:guest}
 
 # HikariCP Connection Pooling
 spring.datasource.hikari.maximum-pool-size=20


### PR DESCRIPTION
Closes #129

## Problem
With no \.env\, the broker is created with \Atlas_rabbit\/\changeme_rabbit_pass\ while every client defaulted to \guest:guest\ — \ACCESS_REFUSED\, reconnect loops, no events. \.env.example\ made it worse by documenting \RABBITMQ_PASSWORD\ while compose reads \RABBITMQ_PASS\.

## Changes
**docker-compose.yml**
- Broker (\
abbitmq\) unchanged: \\\ / \\\
- Client URLs (integration, employee, notification) now default to the same \tlas_rabbit\/\changeme_rabbit_pass\ creds instead of \guest:guest\
- payroll-service: added \SPRING_RABBITMQ_USERNAME\/\SPRING_RABBITMQ_PASSWORD\ (same interpolation) — Spring previously fell back to Spring's built-in \guest\ default
- analytics-service: added the matching \RABBITMQ_URL\ (its consumer previously had no broker config at all)

**.env.example** (root): \RABBITMQ_PASSWORD\ → \RABBITMQ_PASS\ in both service sections, values now match broker defaults. Service-level \.env.example\ files (employee-python, integration, notification-go) updated to the same creds.

**Code defaults** (used when the env var is absent):
- attendance-service/main.go (x2) and notification-go-service/main.go — go from \guest:guest\ to \Atlas_rabbit\/\changeme_rabbit_pass\
- live-service/main.py and integration-service/event_router.py — same
- payroll \Application.properties\ — added \spring.rabbitmq.username/password\ with \SPRING_RABBITMQ_*\ env overrides (local \guest\ default preserved for bare-local runs)

## Verification
- \docker compose config\: YAML parses; broker + all 5 clients share the same variable-interpolated credentials (validated via Python since docker CLI unavailable locally)
- \go build ./...\ passes in attendance-service and notification-go-service (exit 0)
- \python -m py_compile\ passes for touched Python files; flake8 diffs clean (remaining hits are pre-existing, non-fatal style issues)
- No RabbitMQ \guest:guest\ references remain anywhere in compose/env/config samples

## Notes
Not merged to \main\; CI will exercise Go/Python/Java builds on this branch.